### PR TITLE
Fix Hugo compatibility, social icons, and update CI

### DIFF
--- a/.github/workflows/blogger.yml
+++ b/.github/workflows/blogger.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6
       with:
-        go-version: "1.25"
+        go-version: "1.26"
 
     - if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.155.2'
+          hugo-version: '0.157.0'
           extended: true
 
       - name: Build

--- a/themes/seriousben/assets/scss/style.scss
+++ b/themes/seriousben/assets/scss/style.scss
@@ -288,6 +288,11 @@ li code, p code {
 	display: inline-block;
 	text-decoration: none;
     border: none;
+    margin-right: 0.15em;
+}
+
+.social a:last-child {
+    margin-right: 0;
 }
 
 .social a.icon {

--- a/themes/seriousben/layouts/_default/baseof.html
+++ b/themes/seriousben/layouts/_default/baseof.html
@@ -31,7 +31,7 @@
     <link rel="canonical" href="{{ .Permalink }}">
 
     {{ $options := (dict "targetPath" "style.css" "outputStyle" "compressed" "enableSourceMap" true) -}}
-    {{ $style := resources.Get "scss/style.scss" | css.Sass $options | fingerprint -}}
+    {{ $style := resources.Get "scss/style.scss" | toCSS $options | fingerprint -}}
 	<link rel="stylesheet" href="{{ $style.Permalink }}" {{ printf "integrity=%q" $style.Data.Integrity | safeHTMLAttr }} crossorigin="anonymous">
 
     {{ if .Site.Params.highlightjs }}

--- a/themes/seriousben/layouts/index.html
+++ b/themes/seriousben/layouts/index.html
@@ -12,14 +12,8 @@
             I am passionate about technology, beautiful code, and elegant systems.
             <span class="social">
                 {{ partial "footer_github" . }}
-            </span>
-            <span class="social">
                 {{ partial "footer_linkedin" . }}
-            </span>
-            <span class="social">
-                {{ partial "footer_twitter" . }}
-            </span>
-            <span class="social">
+                {{/* {{ partial "footer_twitter" . }} */}}
                 {{ partial "footer_rss" . }}
             </span>
         </p>


### PR DESCRIPTION
## Summary

- **Hugo compatibility**: Fix deprecated `css.Sass` → `toCSS`
- **Social icons**: Consolidate spans, tighten spacing (0.15em), remove Twitter/X
- **CI/CD updates**: Hugo 0.155.2 → 0.157.0, Go 1.25 → 1.26

## Changes

| File | Change |
|------|--------|
| `themes/seriousben/layouts/_default/baseof.html` | Fix deprecated `css.Sass` to `toCSS` |
| `themes/seriousben/layouts/index.html` | Consolidate social spans, comment out Twitter/X |
| `themes/seriousben/assets/scss/style.scss` | Tighten icon spacing to 0.15em |
| `.github/workflows/deploy.yml` | Update Hugo 0.155.2 → 0.157.0 |
| `.github/workflows/blogger.yml` | Update Go 1.25 → 1.26 |