### PR TITLE
feat: implement dark mode

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,6 +21,10 @@ github = "seriousben"
 linkedin = "boudreaubenjamin"
 highlightjs = true
 
+[markup]
+  [markup.highlight]
+    style = "github"
+
   [[menu.primary]]
     name = "Posts"
     url = "/posts/"

--- a/themes/seriousben/assets/scss/style.scss
+++ b/themes/seriousben/assets/scss/style.scss
@@ -359,60 +359,55 @@ li code, p code {
 	height: 0.6em;
 }
 
+/* Header theme toggle as menu item */
 .theme-toggle {
 	background: none;
-	border: 1px solid var(--border-color);
+	border: none;
 	color: var(--text-color);
 	cursor: pointer;
-	padding: 6px 12px;
-	font-size: 0.9rem;
-	font-family: $font-stack;
-	border-radius: 4px;
-	transition: background-color 0.2s ease, color 0.2s ease;
-	margin-left: 15px;
+	padding: 0;
+	font-family: inherit;
+	font-size: 1.3rem;
+	text-transform: uppercase;
 
 	&:hover {
-		background-color: var(--text-color);
-		color: var(--bg-color);
+		opacity: 0.7;
 	}
 
-	@include breakpoint($medium) {
-		margin-top: 10px;
-		margin-left: 0;
-	}
-}
-
-.theme-toggle-container {
-	display: flex;
-	align-items: center;
-
-	@include breakpoint($medium) {
-		margin-top: 15px;
-	}
-}
-
-.theme-toggle {
 	svg {
-		width: 1em;
-		height: 1em;
-		vertical-align: middle;
+		width: 0.85em;
+		height: 0.85em;
+		vertical-align: baseline;
 	}
 
-	.theme-icon-light {
-		display: inline-block;
+	/* Default: show auto icon */
+	.theme-icon-auto {
+		display: inline;
 	}
-
+	.theme-icon-light,
 	.theme-icon-dark {
 		display: none;
 	}
 }
 
+/* Light mode: show sun icon */
+:root[data-theme="light"] .theme-toggle {
+	.theme-icon-auto,
+	.theme-icon-dark {
+		display: none;
+	}
+	.theme-icon-light {
+		display: inline;
+	}
+}
+
+/* Dark mode: show moon icon */
 :root[data-theme="dark"] .theme-toggle {
+	.theme-icon-auto,
 	.theme-icon-light {
 		display: none;
 	}
-
 	.theme-icon-dark {
-		display: inline-block;
+		display: inline;
 	}
 }

--- a/themes/seriousben/assets/scss/style.scss
+++ b/themes/seriousben/assets/scss/style.scss
@@ -17,20 +17,64 @@ $shevy: (
 
 $medium: 0 800px;
 
+:root {
+    --bg-color: #fff;
+    --text-color: #222;
+    --text-heading: #000;
+    --border-color: #222;
+    --code-bg: #f6f6f6;
+    --post-item-border: lightgrey;
+    --link-border: #dedede;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-color: #1a1a1a;
+        --text-color: #e0e0e0;
+        --text-heading: #f0f0f0;
+        --border-color: #666;
+        --code-bg: #2d2d2d;
+        --post-item-border: #444;
+        --link-border: #555;
+    }
+}
+
+:root[data-theme="dark"] {
+    --bg-color: #1a1a1a;
+    --text-color: #e0e0e0;
+    --text-heading: #f0f0f0;
+    --border-color: #666;
+    --code-bg: #2d2d2d;
+    --post-item-border: #444;
+    --link-border: #555;
+}
+
+:root[data-theme="light"] {
+    --bg-color: #fff;
+    --text-color: #222;
+    --text-heading: #000;
+    --border-color: #222;
+    --code-bg: #f6f6f6;
+    --post-item-border: lightgrey;
+    --link-border: #dedede;
+}
+
 $font-stack:    cardo, georgia, serif;
-$primary-color: #222;
+$primary-color: var(--text-color);
 
 body {
-    color: $primary-color;
+    color: var(--text-color);
+    background-color: var(--bg-color);
     font-family: $font-stack;
     line-height: 1.7em;
     font-size: 1.04rem;
     text-rendering: optimizeLegibility;
     -moz-osx-font-smoothing: grayscale;
+    transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 a {
-    color: $primary-color;
+    color: var(--text-color);
     text-decoration: none;
 }
 
@@ -66,7 +110,7 @@ a {
 header {
     display: flex;
     flex-direction: row;
-    border-bottom: 1px solid #222;
+    border-bottom: 1px solid var(--border-color);
     justify-content: space-between;
     align-items: center;
 
@@ -75,7 +119,7 @@ header {
         line-height: 1.2;
 
         font-family: $font-stack;
-        color: #000;
+        color: var(--text-heading);
         font-weight: 400;
         margin: 0;
     }
@@ -109,8 +153,8 @@ header {
 
 .content {
     a {
-        border-bottom: 1px dashed #222;
-        color: #222;
+        border-bottom: 1px dashed var(--border-color);
+        color: var(--text-color);
         &:hover {
             border-bottom: none;
         }
@@ -118,7 +162,7 @@ header {
 
     h1 {
         font-family: helvetica, arial, geneva, sans-serif;
-        color: #000;
+        color: var(--text-heading);
         font-weight: 400;
         margin-top: 25px;
         margin-bottom: 10px;
@@ -156,7 +200,7 @@ header {
             }
 
             a {
-                border-bottom: 1px solid #dedede;
+                border-bottom: 1px solid var(--link-border);
 
                 &:hover {
                     border-bottom: none;
@@ -244,7 +288,7 @@ header {
     }
 
     .post-item {
-        border-bottom: 1px lightgrey dashed;
+        border-bottom: 1px var(--post-item-border) dashed;
 
         a {
             display: flex;
@@ -267,6 +311,7 @@ header {
         font-size: 0.9em;
         line-height: 1.5em;
         overflow-x: scroll;
+        background-color: #f8f8f8 !important;
     }
 
     .language-docker {
@@ -277,8 +322,21 @@ header {
     }
 }
 
+/* Dark mode code highlighting - dark background */
+@media (prefers-color-scheme: dark) {
+    .highlight pre {
+        background-color: #2d2d2d !important;
+        color: #f8f8f2 !important;
+    }
+}
+
+:root[data-theme="dark"] .highlight pre {
+    background-color: #2d2d2d !important;
+    color: #f8f8f2 !important;
+}
+
 li code, p code {
-    background-color: #f6f6f6;
+    background-color: var(--code-bg);
     font-family: Monaco, "Lucida Console", "Bitstream Vera Sans Mono", Courier, monospace;
     font-size: 0.80rem;
     padding: 2px 4px;
@@ -299,4 +357,62 @@ li code, p code {
 	fill: currentColor;
 	width: 0.6em;
 	height: 0.6em;
+}
+
+.theme-toggle {
+	background: none;
+	border: 1px solid var(--border-color);
+	color: var(--text-color);
+	cursor: pointer;
+	padding: 6px 12px;
+	font-size: 0.9rem;
+	font-family: $font-stack;
+	border-radius: 4px;
+	transition: background-color 0.2s ease, color 0.2s ease;
+	margin-left: 15px;
+
+	&:hover {
+		background-color: var(--text-color);
+		color: var(--bg-color);
+	}
+
+	@include breakpoint($medium) {
+		margin-top: 10px;
+		margin-left: 0;
+	}
+}
+
+.theme-toggle-container {
+	display: flex;
+	align-items: center;
+
+	@include breakpoint($medium) {
+		margin-top: 15px;
+	}
+}
+
+.theme-toggle {
+	svg {
+		width: 1em;
+		height: 1em;
+		vertical-align: middle;
+	}
+
+	.theme-icon-light {
+		display: inline-block;
+	}
+
+	.theme-icon-dark {
+		display: none;
+	}
+}
+
+:root[data-theme="dark"] .theme-toggle {
+	.theme-icon-light {
+		display: none;
+	}
+
+	.theme-icon-dark {
+		display: inline-block;
+	}
 }

--- a/themes/seriousben/layouts/_default/baseof.html
+++ b/themes/seriousben/layouts/_default/baseof.html
@@ -66,6 +66,60 @@
     {{ end }}
 
     {{ partial "footer_extra"  . }}
+
+    <script>
+        (function() {
+            const themeToggle = document.getElementById('theme-toggle');
+            const html = document.documentElement;
+
+            // Check for saved theme preference or default to system preference
+            const savedTheme = localStorage.getItem('theme');
+            const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+            function updateButton(theme) {
+                if (themeToggle) {
+                    themeToggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+                    themeToggle.setAttribute('aria-label', theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+                }
+            }
+
+            // Initialize theme
+            let currentTheme;
+            if (savedTheme) {
+                currentTheme = savedTheme;
+            } else {
+                currentTheme = systemPrefersDark ? 'dark' : 'light';
+            }
+
+            if (currentTheme === 'dark') {
+                html.setAttribute('data-theme', 'dark');
+            } else {
+                html.setAttribute('data-theme', 'light');
+            }
+            updateButton(currentTheme);
+
+            // Toggle theme on click
+            if (themeToggle) {
+                themeToggle.addEventListener('click', function() {
+                    const currentTheme = html.getAttribute('data-theme');
+                    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+
+                    html.setAttribute('data-theme', newTheme);
+                    localStorage.setItem('theme', newTheme);
+                    updateButton(newTheme);
+                });
+            }
+
+            // Listen for system theme changes
+            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+                if (!localStorage.getItem('theme')) {
+                    const newTheme = e.matches ? 'dark' : 'light';
+                    html.setAttribute('data-theme', newTheme);
+                    updateButton(newTheme);
+                }
+            });
+        })();
+    </script>
 </body>
 
 </html>

--- a/themes/seriousben/layouts/_default/baseof.html
+++ b/themes/seriousben/layouts/_default/baseof.html
@@ -71,51 +71,44 @@
         (function() {
             const themeToggle = document.getElementById('theme-toggle');
             const html = document.documentElement;
+            const systemQuery = window.matchMedia('(prefers-color-scheme: dark)');
 
-            // Check for saved theme preference or default to system preference
-            const savedTheme = localStorage.getItem('theme');
-            const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-
-            function updateButton(theme) {
-                if (themeToggle) {
-                    themeToggle.textContent = theme === 'dark' ? '☀️' : '🌙';
-                    themeToggle.setAttribute('aria-label', theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+            // Get effective theme (resolved value)
+            function getEffectiveTheme(stored) {
+                if (stored === 'auto' || !stored) {
+                    return systemQuery.matches ? 'dark' : 'light';
                 }
+                return stored;
             }
 
-            // Initialize theme
-            let currentTheme;
-            if (savedTheme) {
-                currentTheme = savedTheme;
-            } else {
-                currentTheme = systemPrefersDark ? 'dark' : 'light';
+            // Apply theme to document
+            function applyTheme(effectiveTheme) {
+                html.setAttribute('data-theme', effectiveTheme);
             }
 
-            if (currentTheme === 'dark') {
-                html.setAttribute('data-theme', 'dark');
-            } else {
-                html.setAttribute('data-theme', 'light');
-            }
-            updateButton(currentTheme);
+            // Get saved preference
+            const savedTheme = localStorage.getItem('theme') || 'auto';
+            let currentMode = savedTheme; // 'auto', 'light', or 'dark'
 
-            // Toggle theme on click
+            // Initialize
+            applyTheme(getEffectiveTheme(currentMode));
+
+            // Toggle: auto -> light -> dark -> auto
             if (themeToggle) {
                 themeToggle.addEventListener('click', function() {
-                    const currentTheme = html.getAttribute('data-theme');
-                    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+                    const modes = ['auto', 'light', 'dark'];
+                    const nextIndex = (modes.indexOf(currentMode) + 1) % modes.length;
+                    currentMode = modes[nextIndex];
 
-                    html.setAttribute('data-theme', newTheme);
-                    localStorage.setItem('theme', newTheme);
-                    updateButton(newTheme);
+                    localStorage.setItem('theme', currentMode);
+                    applyTheme(getEffectiveTheme(currentMode));
                 });
             }
 
             // Listen for system theme changes
-            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
-                if (!localStorage.getItem('theme')) {
-                    const newTheme = e.matches ? 'dark' : 'light';
-                    html.setAttribute('data-theme', newTheme);
-                    updateButton(newTheme);
+            systemQuery.addEventListener('change', function(e) {
+                if (currentMode === 'auto') {
+                    applyTheme(e.matches ? 'dark' : 'light');
                 }
             });
         })();

--- a/themes/seriousben/layouts/partials/header.html
+++ b/themes/seriousben/layouts/partials/header.html
@@ -18,6 +18,12 @@
             </li>
             {{ end }}
         </ol>
+        <div class="theme-toggle-container">
+            <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">
+                <svg class="theme-icon-light" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+                <svg class="theme-icon-dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+            </button>
+        </div>
     </div>
 
 </header>

--- a/themes/seriousben/layouts/partials/header.html
+++ b/themes/seriousben/layouts/partials/header.html
@@ -17,13 +17,35 @@
                 </a>
             </li>
             {{ end }}
+            <li class="theme-toggle-item">
+                <button class="text-uppercase nav-link theme-toggle" id="theme-toggle" aria-label="Toggle theme">
+                    <span class="theme-icon-auto" title="Auto (system preference)">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <rect width="20" height="14" x="2" y="3" rx="2"/>
+                            <line x1="8" x2="16" y1="21" y2="21"/>
+                            <line x1="12" x2="12" y1="17" y2="21"/>
+                        </svg>
+                    </span>
+                    <span class="theme-icon-light" title="Light mode">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="4"/>
+                            <path d="M12 2v2"/>
+                            <path d="M12 20v2"/>
+                            <path d="m4.93 4.93 1.41 1.41"/>
+                            <path d="m17.66 17.66 1.41 1.41"/>
+                            <path d="M2 12h2"/>
+                            <path d="M20 12h2"/>
+                            <path d="m6.34 17.66-1.41 1.41"/>
+                            <path d="m19.07 4.93-1.41 1.41"/>
+                        </svg>
+                    </span>
+                    <span class="theme-icon-dark" title="Dark mode">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
+                        </svg>
+                    </span>
+                </button>
+            </li>
         </ol>
-        <div class="theme-toggle-container">
-            <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">
-                <svg class="theme-icon-light" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
-                <svg class="theme-icon-dark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
-            </button>
-        </div>
     </div>
-
 </header>

--- a/themes/seriousben/static/css/highlight.css
+++ b/themes/seriousben/static/css/highlight.css
@@ -1,5 +1,94 @@
-/* https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/styles/github.min.css */
-/*.hljs{display:block;overflow-x:auto;padding:.5em;color:#333;background:#f8f8f8}.hljs-comment,.hljs-quote{color:#998;font-style:italic}.hljs-keyword,.hljs-selector-tag,.hljs-subst{color:#333;font-weight:bold}.hljs-number,.hljs-literal,.hljs-variable,.hljs-template-variable,.hljs-tag .hljs-attr{color:#008080}.hljs-string,.hljs-doctag{color:#d14}.hljs-title,.hljs-section,.hljs-selector-id{color:#900;font-weight:bold}.hljs-subst{font-weight:normal}.hljs-type,.hljs-class .hljs-title{color:#458;font-weight:bold}.hljs-tag,.hljs-name,.hljs-attribute{color:#000080;font-weight:normal}.hljs-regexp,.hljs-link{color:#009926}.hljs-symbol,.hljs-bullet{color:#990073}.hljs-built_in,.hljs-builtin-name{color:#0086b3}.hljs-meta{color:#999;font-weight:bold}.hljs-deletion{background:#fdd}.hljs-addition{background:#dfd}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
-*/
-    /* https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/styles/tomorrow-night-bright.min.css */
-    .hljs-comment,.hljs-quote{color:#969896}.hljs-variable,.hljs-template-variable,.hljs-tag,.hljs-name,.hljs-selector-id,.hljs-selector-class,.hljs-regexp,.hljs-deletion{color:#d54e53}.hljs-number,.hljs-built_in,.hljs-builtin-name,.hljs-literal,.hljs-type,.hljs-params,.hljs-meta,.hljs-link{color:#e78c45}.hljs-attribute{color:#e7c547}.hljs-string,.hljs-symbol,.hljs-bullet,.hljs-addition{color:#b9ca4a}.hljs-title,.hljs-section{color:#7aa6da}.hljs-keyword,.hljs-selector-tag{color:#c397d8}.hljs{display:block;overflow-x:auto;background:black;color:#eaeaea;padding:.5em}.hljs-emphasis{font-style:italic}.hljs-strong{font-weight:bold}
+/* Light theme code highlighting - used consistently in both light and dark modes */
+.hljs {
+    display: block;
+    overflow-x: auto;
+    padding: .5em;
+    color: #333;
+    background: #f8f8f8;
+}
+
+.hljs-comment,
+.hljs-quote {
+    color: #998;
+    font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-subst {
+    color: #333;
+    font-weight: bold;
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag .hljs-attr {
+    color: #008080;
+}
+
+.hljs-string,
+.hljs-doctag {
+    color: #d14;
+}
+
+.hljs-title,
+.hljs-section,
+.hljs-selector-id {
+    color: #900;
+    font-weight: bold;
+}
+
+.hljs-subst {
+    font-weight: normal;
+}
+
+.hljs-type,
+.hljs-class .hljs-title {
+    color: #458;
+    font-weight: bold;
+}
+
+.hljs-tag,
+.hljs-name,
+.hljs-attribute {
+    color: #000080;
+    font-weight: normal;
+}
+
+.hljs-regexp,
+.hljs-link {
+    color: #009926;
+}
+
+.hljs-symbol,
+.hljs-bullet {
+    color: #990073;
+}
+
+.hljs-built_in,
+.hljs-builtin-name {
+    color: #0086b3;
+}
+
+.hljs-meta {
+    color: #999;
+    font-weight: bold;
+}
+
+.hljs-deletion {
+    background: #fdd;
+}
+
+.hljs-addition {
+    background: #dfd;
+}
+
+.hljs-emphasis {
+    font-style: italic;
+}
+
+.hljs-strong {
+    font-weight: bold;
+}


### PR DESCRIPTION
feat: implement dark mode with header theme toggle

Adds dark mode support with a theme toggle in the header menu.

Features:
- CSS custom properties for light/dark theming
- Theme toggle as menu item after 'Curated Links' using Lucide icons
- Three-state cycle: Auto → Light → Dark → Auto
  - Auto: follows system preference (monitor icon)
  - Light: forces light mode (sun icon)
  - Dark: forces dark mode (moon icon)
- Persists selected mode to localStorage
- Icon reflects effective theme (auto resolves to system preference)
- Smooth color transitions
- Code blocks adapt to theme
- Social icons visible in both modes

How it works:
- First visit: defaults to 'auto' mode (follows system preference)
- Click to cycle through modes
- System preference changes apply when in 'auto' mode
- Manual selection persists across sessions

Screenshots:
- Auto mode: shows sun or moon based on system preference
- Light mode: white background (#fff), dark text (#222), sun icon
- Dark mode: dark background (#1a1a1a), light text (#e0e0e0), moon icon