### PR TITLE
Add tools section to blog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+## Tools Section
+
+The site has a `/tools/` section for self-contained HTML/CSS/JS tools.
+
+### Structure
+
+- `content/tools/<slug>.md` — metadata only (title, date, summary, tags, toolUrl). No rendered page (cascade sets `build: render: never`).
+- `static/tools/<slug>/` — the actual tool. Plain HTML/CSS/JS, Hugo serves as-is.
+- `content/tools/_index.md` — section listing page at `/tools/`.
+
+### Adding a new tool
+
+```bash
+./new-tool <name>
+# e.g. ./new-tool color-picker
+```
+
+This creates the content file and static folder together. Fill in `summary` and `tags` in the generated markdown, then build the tool in `static/tools/<slug>/`.
+
+### Front matter fields
+
+| Field     | Purpose                                      |
+|-----------|----------------------------------------------|
+| `title`   | Display name on the card                     |
+| `date`    | Created date (shown on card)                 |
+| `summary` | One-line description on the card              |
+| `tags`    | Tag pills on the card                        |
+| `toolUrl` | Path to the static tool (e.g. `/tools/<slug>/`) |
+
+### Dates
+
+- **Created** comes from the `date` front matter field.
+- **Updated** comes from git (via `enableGitInfo` in config). Hugo reads the last commit that touched the content file.
+- Updated only displays when it differs from Created.
+
+### Validation
+
+```bash
+./validate-tools
+```
+
+Checks that every content file with `toolUrl` has a matching `static/tools/` folder with `index.html`, and vice versa.
+
+### Key constraint
+
+Content files in `content/tools/` must not render individual pages (the cascade ensures this). The card on `/tools/` is the full Hugo-side presence. The `toolUrl` links directly to the static tool app.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HUGO_VERSION := 0.155.2
 DOCKER_IMAGE := hugomods/hugo:$(HUGO_VERSION)
 DOCKER_RUN := docker run --rm -v "$(PWD):/src" -w /src
 
-.PHONY: build serve stop clean
+.PHONY: build serve stop clean validate-tools new-tool
 
 build:
 	$(DOCKER_RUN) $(DOCKER_IMAGE) hugo --minify
@@ -15,6 +15,15 @@ serve:
 
 stop:
 	docker stop hugo-server
+
+validate-tools:
+	./validate-tools
+
+new-tool:
+	@./new-tool $(filter-out $@,$(MAKECMDGOALS))
+
+%:
+	@:
 
 clean:
 	rm -rf public resources

--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,7 @@ title = "Benjamin Boudreau"
 copyright = "Copyright © Benjamin Boudreau 2017-2020"
 theme = "seriousben"
 rssLimit = 100
+enableGitInfo = true
 enableEmoji = true
 [author]
   name = "Benjamin Boudreau"
@@ -31,6 +32,11 @@ highlightjs = true
     weight = 10
 
   [[menu.primary]]
+    name = "Tools"
+    url = "/tools/"
+    weight = 20
+
+  [[menu.primary]]
     name = "Curated Links"
     url = "/links/"
-    weight = 20
+    weight = 30

--- a/content/tools/_index.md
+++ b/content/tools/_index.md
@@ -1,0 +1,10 @@
+---
+title: Tools
+build:
+  render: true
+  list: local
+cascade:
+  build:
+    render: never
+    list: local
+---

--- a/content/tools/multi-term-mortgage-calculator.md
+++ b/content/tools/multi-term-mortgage-calculator.md
@@ -1,0 +1,7 @@
+---
+title: "Multi-term Mortgage Calculator"
+date: 2026-05-05
+summary: "Compare multiple mortgage terms side by side to find the best repayment strategy."
+tags: ["finance", "mortgage", "calculator"]
+toolUrl: "/tools/multi-term-mortgage-calculator/"
+---

--- a/layouts/tools/list.html
+++ b/layouts/tools/list.html
@@ -1,0 +1,34 @@
+{{ define "main" }}
+    {{ partial "header" . }}
+
+    <div class="content">
+        <h1>{{ .Title }}</h1>
+
+        <div>
+            {{ partial "content" . }}
+        </div>
+
+        <div class="tools-list">
+            {{- range .Pages }}
+            <div class="tool-card">
+                <h2 class="tool-title">{{ .Title }}</h2>
+                <div class="tool-dates">
+                    <span class="tool-date">Created {{ .Date.Format "Jan 2, 2006" }}</span>
+                    {{ $created := .Date }}{{ with .GitInfo }}{{ if ne (.AuthorDate.Format "2006-01-02") ($created.Format "2006-01-02") }}<span class="tool-date">Updated {{ .AuthorDate.Format "Jan 2, 2006" }}</span>{{ end }}{{ end }}
+                </div>
+                {{ with .Params.summary }}<p class="tool-summary">{{ . }}</p>{{ end }}
+                {{ with .Params.tags }}
+                <div class="tool-tags">
+                    {{- range . }}<span class="tool-tag">{{ . }}</span>{{ end }}
+                </div>
+                {{ end }}
+                {{ with .Params.toolUrl }}
+                <a class="tool-cta" href="{{ . }}" target="_blank" rel="noopener">Open tool &rarr;</a>
+                {{ end }}
+            </div>
+            {{- end }}
+        </div>
+    </div>
+
+    {{ partial "footer" . }}
+{{ end }}

--- a/new-tool
+++ b/new-tool
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: new-tool <name>"
+    echo "  e.g. new-tool color-picker"
+    exit 1
+fi
+
+NAME="$1"
+SLUG="$(echo "$NAME" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')"
+POST="content/tools/${SLUG}.md"
+DIR="static/tools/${SLUG}"
+
+if [ -f "$POST" ]; then
+    echo "Error: ${POST} already exists" >&2
+    exit 1
+fi
+
+if [ -d "$DIR" ]; then
+    echo "Error: ${DIR} already exists" >&2
+    exit 1
+fi
+
+DATE="$(date +%Y-%m-%d)"
+TITLE="$(echo "$NAME" | sed 's/-/ /g' | sed 's/\b\(.\)/\u\1/g')"
+
+cat > "$POST" <<EOF
+---
+title: "${TITLE}"
+date: ${DATE}
+summary: ""
+tags: []
+toolUrl: "/tools/${SLUG}/"
+---
+EOF
+
+mkdir -p "$DIR"
+cat > "${DIR}/index.html" <<EOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>${TITLE}</title>
+    <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+    <h1>${TITLE}</h1>
+    <script src="./script.js"></script>
+</body>
+</html>
+EOF
+
+touch "${DIR}/style.css"
+touch "${DIR}/script.js"
+
+echo "Created:"
+echo "  ${POST}"
+echo "  ${DIR}/index.html"
+echo "  ${DIR}/style.css"
+echo "  ${DIR}/script.js"

--- a/static/tools/multi-term-mortgage-calculator/index.html
+++ b/static/tools/multi-term-mortgage-calculator/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Multi-term Mortgage Calculator</title>
+    <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+    <h1>Multi-term Mortgage Calculator</h1>
+    <p><em>Placeholder — full tool coming soon.</em></p>
+    <script src="./script.js"></script>
+</body>
+</html>

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -1,0 +1,1 @@
+// Multi-term mortgage calculator — placeholder

--- a/static/tools/multi-term-mortgage-calculator/style.css
+++ b/static/tools/multi-term-mortgage-calculator/style.css
@@ -1,0 +1,6 @@
+body {
+    font-family: system-ui, sans-serif;
+    max-width: 700px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+}

--- a/themes/seriousben/assets/scss/style.scss
+++ b/themes/seriousben/assets/scss/style.scss
@@ -423,3 +423,68 @@ li code, p code {
 		display: inline;
 	}
 }
+
+/* Tools section */
+.tools-list {
+    display: grid;
+    gap: 1.5em;
+    max-width: 700px;
+}
+
+.tool-card {
+    border: 1px solid var(--post-item-border);
+    border-radius: 4px;
+    padding: 1.2em 1.5em;
+}
+
+.tool-title {
+    font-family: helvetica, arial, geneva, sans-serif;
+    font-weight: 400;
+    font-size: 1.3em;
+    margin: 0 0 0.3em;
+    color: var(--text-heading);
+}
+
+.tool-dates {
+    margin-bottom: 0.5em;
+}
+
+.tool-date {
+    font-size: 0.82em;
+    color: var(--text-color);
+    opacity: 0.7;
+    margin-right: 1em;
+}
+
+.tool-summary {
+    margin: 0 0 0.8em;
+    max-width: 550px;
+}
+
+.tool-tags {
+    margin-bottom: 0.8em;
+}
+
+.tool-tag {
+    display: inline-block;
+    font-size: 0.78em;
+    border: 1px solid var(--post-item-border);
+    border-radius: 3px;
+    padding: 2px 8px;
+    margin-right: 6px;
+}
+
+.tool-cta {
+    display: inline-block;
+    border: 1px solid var(--border-color);
+    border-radius: 3px;
+    padding: 6px 16px;
+    font-size: 0.9em;
+    text-decoration: none;
+    color: var(--text-color);
+
+    &:hover {
+        background-color: var(--text-color);
+        color: var(--bg-color);
+    }
+}

--- a/validate-tools
+++ b/validate-tools
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate that every tool content file with toolUrl has a matching static folder
+# and that every static/tool/ folder has a matching content file.
+
+ERRORS=0
+
+for md in content/tools/*.md; do
+    [ -f "$md" ] || continue
+    [ "$(basename "$md")" = "_index.md" ] && continue
+
+    TOOL_URL="$(grep -oP 'toolUrl:\s*"([^"]+)"' "$md" | head -1 | sed 's/toolUrl: *"//;s/"$//' | sed 's:/$::')"
+    if [ -z "$TOOL_URL" ]; then
+        echo "WARN: $(basename "$md") has no toolUrl"
+        continue
+    fi
+
+    STATIC_DIR="static${TOOL_URL}"
+    if [ ! -d "$STATIC_DIR" ]; then
+        echo "ERROR: $(basename "$md") references ${TOOL_URL}/ but ${STATIC_DIR} does not exist"
+        ERRORS=$((ERRORS + 1))
+    elif [ ! -f "${STATIC_DIR}/index.html" ]; then
+        echo "ERROR: ${STATIC_DIR}/index.html missing"
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+for dir in static/tool/*/; do
+    [ -d "$dir" ] || continue
+    SLUG="$(basename "$dir")"
+    if [ ! -f "content/tools/${SLUG}.md" ]; then
+        echo "ERROR: ${dir} has no matching content/tools/${SLUG}.md"
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+if [ "$ERRORS" -gt 0 ]; then
+    echo ""
+    echo "Validation failed with ${ERRORS} error(s)"
+    exit 1
+fi
+
+echo "All tools validated OK"


### PR DESCRIPTION

Why
- Add a /tools/ section to the site for self-contained HTML/CSS/JS tools

What
- Tools section with card listing (title, created/updated dates from git, summary, tags, CTA button)
- Content files in content/tools/ provide metadata only (render: never via cascade)
- Static tool apps in static/tools/<slug>/ served as-is, no Hugo pipeline
- First tool: multi-term mortgage calculator (placeholder)
- new-tool scaffolding script, validate-tools consistency check
- Tools nav item in main menu
- enableGitInfo for updated dates inferred from git history
