### PR TITLE
Mortgage calculator: scenarios, dark mode, bug fixes

### DIFF
--- a/new-tool
+++ b/new-tool
@@ -44,16 +44,151 @@ cat > "${DIR}/index.html" <<EOF
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>${TITLE}</title>
     <link rel="stylesheet" href="./style.css">
+    <script>
+        (function() {
+            var q = window.matchMedia('(prefers-color-scheme: dark)');
+            var saved = localStorage.getItem('theme') || 'auto';
+            function resolve(m) { return m === 'auto' ? (q.matches ? 'dark' : 'light') : m; }
+            document.documentElement.setAttribute('data-theme', resolve(saved));
+            document.documentElement.setAttribute('data-theme-mode', saved);
+        })();
+    </script>
 </head>
 <body>
+    <div class="header-row">
+        <button id="theme-toggle" class="theme-toggle" title="Toggle theme">
+            <span class="theme-icon theme-icon-auto">Auto</span>
+            <span class="theme-icon theme-icon-light">Light</span>
+            <span class="theme-icon theme-icon-dark">Dark</span>
+        </button>
+    </div>
     <h1>${TITLE}</h1>
+    <script>
+        (function() {
+            var toggle = document.getElementById('theme-toggle');
+            var html = document.documentElement;
+            var q = window.matchMedia('(prefers-color-scheme: dark)');
+            function resolve(m) { return m === 'auto' ? (q.matches ? 'dark' : 'light') : m; }
+            function apply(m) {
+                html.setAttribute('data-theme', resolve(m));
+                html.setAttribute('data-theme-mode', m);
+            }
+            var mode = localStorage.getItem('theme') || 'auto';
+            if (toggle) {
+                toggle.addEventListener('click', function() {
+                    var modes = ['auto', 'light', 'dark'];
+                    mode = modes[(modes.indexOf(mode) + 1) % 3];
+                    localStorage.setItem('theme', mode);
+                    apply(mode);
+                });
+            }
+            q.addEventListener('change', function(e) {
+                if (mode === 'auto') html.setAttribute('data-theme', e.matches ? 'dark' : 'light');
+            });
+        })();
+    </script>
     <script src="./script.js"></script>
 </body>
 </html>
 EOF
 
-touch "${DIR}/style.css"
 touch "${DIR}/script.js"
+
+cat > "${DIR}/style.css" <<CSSEOF
+:root {
+    --bg: #fafafa;
+    --surface: #fff;
+    --text: #111;
+    --text-2: #555;
+    --text-3: #888;
+    --border: #e2e2e2;
+    --border-focus: #111;
+    --accent: #111;
+    --accent-soft: #f3f3f3;
+    --radius: 2px;
+    --mono: "SF Mono", "Roboto Mono", "Menlo", monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #1a1a1a;
+        --surface: #242424;
+        --text: #e0e0e0;
+        --text-2: #aaa;
+        --text-3: #777;
+        --border: #444;
+        --border-focus: #999;
+        --accent: #e0e0e0;
+        --accent-soft: #2d2d2d;
+    }
+}
+
+:root[data-theme="dark"] {
+    --bg: #1a1a1a;
+    --surface: #242424;
+    --text: #e0e0e0;
+    --text-2: #aaa;
+    --text-3: #777;
+    --border: #444;
+    --border-focus: #999;
+    --accent: #e0e0e0;
+    --accent-soft: #2d2d2d;
+}
+
+:root[data-theme="light"] {
+    --bg: #fafafa;
+    --surface: #fff;
+    --text: #111;
+    --text-2: #555;
+    --text-3: #888;
+    --border: #e2e2e2;
+    --border-focus: #111;
+    --accent: #111;
+    --accent-soft: #f3f3f3;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
+    max-width: 780px;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 4rem;
+    line-height: 1.55;
+    color: var(--text);
+    background: var(--bg);
+    -webkit-font-smoothing: antialiased;
+}
+
+.header-row {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 1rem;
+}
+
+.theme-toggle {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.3rem 0.75rem;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-3);
+    cursor: pointer;
+    transition: all 0.1s;
+}
+
+.theme-toggle:hover {
+    border-color: var(--text);
+    color: var(--text);
+}
+
+.theme-icon { display: none; }
+:root[data-theme-mode="auto"] .theme-icon-auto,
+:root:not([data-theme-mode]) .theme-icon-auto { display: inline; }
+:root[data-theme-mode="light"] .theme-icon-light { display: inline; }
+:root[data-theme-mode="dark"] .theme-icon-dark { display: inline; }
+CSSEOF
 
 echo "Created:"
 echo "  ${POST}"

--- a/static/tools/multi-term-mortgage-calculator/index.html
+++ b/static/tools/multi-term-mortgage-calculator/index.html
@@ -9,7 +9,7 @@
 <body>
     <!-- Hook -->
     <div id="hook" class="hook">
-        <div class="hook-line">A <span class="hook-value" id="hook-loan">$400,000</span> mortgage costs <span class="hook-value hook-emphasis" id="hook-interest">$XXX</span> in interest alone</div>
+        <div class="hook-line">A <span class="hook-value" id="hook-loan">$400,000</span> mortgage costs <span class="hook-value hook-emphasis" id="hook-interest">$0</span> in interest alone</div>
         <div class="hook-sub">See the full picture before you sign</div>
     </div>
 

--- a/static/tools/multi-term-mortgage-calculator/index.html
+++ b/static/tools/multi-term-mortgage-calculator/index.html
@@ -59,6 +59,33 @@
         <button id="add-term" class="btn-link">+ Add another term</button>
     </div>
 
+    <!-- Expandable: scenarios -->
+    <div class="section collapsible">
+        <button class="section-toggle" id="toggle-scenarios">
+            <span class="section-title">Scenarios</span>
+            <span class="toggle-arrow" id="arrow-scenarios"></span>
+        </button>
+        <div class="section-body collapsed" id="body-scenarios">
+            <p class="scenario-hint">Adjust term rates by a fixed offset to model optimistic (rates fall) or pessimistic (rates rise) outcomes.</p>
+            <div class="input-row">
+                <div class="field">
+                    <label for="rate-optimistic">Optimistic</label>
+                    <div class="input-wrap">
+                        <input type="number" id="rate-optimistic" value="-1" min="-10" max="0" step="0.25">
+                        <span class="suffix">%</span>
+                    </div>
+                </div>
+                <div class="field">
+                    <label for="rate-pessimistic">Pessimistic</label>
+                    <div class="input-wrap">
+                        <input type="number" id="rate-pessimistic" value="2" min="0" max="10" step="0.25">
+                        <span class="suffix">%</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Expandable: prepayments -->
     <div class="section collapsible">
         <button class="section-toggle" id="toggle-prepay">

--- a/static/tools/multi-term-mortgage-calculator/index.html
+++ b/static/tools/multi-term-mortgage-calculator/index.html
@@ -7,195 +7,43 @@
     <link rel="stylesheet" href="./style.css">
 </head>
 <body>
-    <!-- Hook -->
-    <div id="hook" class="hook">
-        <div class="hook-line">A <span class="hook-value" id="hook-loan">$400,000</span> mortgage costs <span class="hook-value hook-emphasis" id="hook-interest">$XXX</span> in interest alone</div>
-        <div class="hook-sub">See the full picture before you sign</div>
-    </div>
+    <h1>Multi-term Mortgage Calculator</h1>
+    <p class="subtitle">Compare mortgage terms side by side</p>
 
-    <div class="header-row">
-        <div class="country-toggle">
-            <button id="btn-ca" class="country-btn active" data-country="ca">Canada</button>
-            <button id="btn-us" class="country-btn" data-country="us">United States</button>
-        </div>
-        <button id="btn-clear" class="clear-btn" title="Reset all values">Clear</button>
-    </div>
-
-    <div id="country-info" class="country-info"></div>
-
-    <!-- Core inputs: always visible -->
-    <div class="section">
-        <div class="input-row core-row">
-            <div class="field">
-                <label for="home-value">Home Value</label>
-                <div class="input-wrap">
-                    <span class="prefix">$</span>
-                    <input type="number" id="home-value" value="500000" min="0" step="1000">
-                </div>
-            </div>
-            <div class="field">
-                <label for="down-payment">Down Payment</label>
-                <div class="input-wrap">
-                    <input type="number" id="down-payment" value="100000" min="0" step="1000">
-                    <span class="suffix" id="down-pct">20%</span>
-                </div>
-            </div>
-            <div class="field">
-                <label for="loan-amount">Loan Amount</label>
-                <div class="input-wrap">
-                    <span class="prefix">$</span>
-                    <input type="number" id="loan-amount" value="400000" min="0" step="1000" readonly>
-                </div>
-            </div>
-            <div class="field">
-                <label for="amortization">Amortization</label>
-                <div class="input-wrap">
-                    <input type="number" id="amortization" value="25" min="1" max="40" step="1">
-                    <span class="suffix">yr</span>
-                </div>
+    <div class="input-section">
+        <div class="field">
+            <label for="principal">Loan Amount</label>
+            <div class="input-wrap">
+                <span class="prefix">$</span>
+                <input type="number" id="principal" value="300000" min="0" step="1000">
             </div>
         </div>
-        <div id="terms-list" class="terms-list"></div>
-        <button id="add-term" class="btn-link">+ Add another term</button>
-    </div>
-
-    <!-- Expandable: prepayments -->
-    <div class="section collapsible">
-        <button class="section-toggle" id="toggle-prepay">
-            <span class="section-title">Prepayments</span>
-            <span class="toggle-arrow" id="arrow-prepay"></span>
-        </button>
-        <div class="section-body collapsed" id="body-prepay">
-            <div class="input-row">
-                <div class="field">
-                    <label for="payment-increase">Increase Payment / Year</label>
-                    <div class="input-wrap">
-                        <span class="prefix">$</span>
-                        <input type="number" id="payment-increase" value="0" min="0" step="25">
-                    </div>
-                </div>
-                <div class="field">
-                    <label for="lump-sum-annual">Lump Sum / Year</label>
-                    <div class="input-wrap">
-                        <span class="prefix">$</span>
-                        <input type="number" id="lump-sum-annual" value="0" min="0" step="500">
-                    </div>
-                </div>
-                <div class="field">
-                    <label for="lump-sum-term">Lump Sum at Renewal</label>
-                    <div class="input-wrap">
-                        <span class="prefix">$</span>
-                        <input type="number" id="lump-sum-term" value="0" min="0" step="1000">
-                    </div>
-                </div>
+        <div class="field">
+            <label for="rate">Annual Interest Rate</label>
+            <div class="input-wrap">
+                <input type="number" id="rate" value="6.5" min="0" max="30" step="0.125">
+                <span class="suffix">%</span>
             </div>
         </div>
     </div>
 
-    <!-- Expandable: recurring costs -->
-    <div class="section collapsible">
-        <button class="section-toggle" id="toggle-costs">
-            <span class="section-title">Recurring Costs</span>
-            <span class="toggle-arrow" id="arrow-costs"></span>
-        </button>
-        <div class="section-body collapsed" id="body-costs">
-            <div class="input-row">
-                <div class="field">
-                    <label for="property-tax" id="property-tax-label">Property Tax / Year</label>
-                    <div class="input-wrap">
-                        <span class="prefix">$</span>
-                        <input type="number" id="property-tax" value="3500" min="0" step="100">
-                    </div>
-                </div>
-                <div class="field">
-                    <label for="home-insurance">Home Insurance / Year</label>
-                    <div class="input-wrap">
-                        <span class="prefix">$</span>
-                        <input type="number" id="home-insurance" value="1200" min="0" step="100">
-                    </div>
-                </div>
-                <div class="field">
-                    <label for="hoa" id="hoa-label">HOA / Month</label>
-                    <div class="input-wrap">
-                        <span class="prefix">$</span>
-                        <input type="number" id="hoa" value="0" min="0" step="25">
-                    </div>
-                </div>
-            </div>
-            <div class="pmi-row" id="pmi-row" style="display:none;">
-                <div class="field">
-                    <label for="pmi" id="pmi-label">Mortgage Insurance</label>
-                    <div class="input-wrap">
-                        <input type="number" id="pmi" value="0" min="0" step="0.01">
-                        <span class="suffix">%/yr</span>
-                    </div>
-                </div>
-            </div>
-            <div class="hint" id="pmi-hint"></div>
+    <div class="terms-section">
+        <label>Mortgage Terms</label>
+        <div class="term-toggles">
+            <button class="term-toggle" data-term="10" aria-pressed="false">10 yr</button>
+            <button class="term-toggle active" data-term="15" aria-pressed="true">15 yr</button>
+            <button class="term-toggle active" data-term="20" aria-pressed="true">20 yr</button>
+            <button class="term-toggle active" data-term="25" aria-pressed="true">25 yr</button>
+            <button class="term-toggle active" data-term="30" aria-pressed="true">30 yr</button>
         </div>
     </div>
 
-    <!-- Expandable: start date -->
-    <div class="section collapsible">
-        <button class="section-toggle" id="toggle-date">
-            <span class="section-title">Start Date</span>
-            <span class="toggle-arrow" id="arrow-date"></span>
-        </button>
-        <div class="section-body collapsed" id="body-date">
-            <div class="input-row">
-                <div class="field">
-                    <label for="start-month">Month</label>
-                    <select id="start-month">
-                        <option value="0">January</option><option value="1">February</option><option value="2">March</option>
-                        <option value="3">April</option><option value="4">May</option><option value="5" selected>June</option>
-                        <option value="6">July</option><option value="7">August</option><option value="8">September</option>
-                        <option value="9">October</option><option value="10">November</option><option value="11">December</option>
-                    </select>
-                </div>
-                <div class="field">
-                    <label for="start-year">Year</label>
-                    <div class="input-wrap">
-                        <input type="number" id="start-year" value="2026" min="2000" max="2050" step="1">
-                    </div>
-                </div>
-            </div>
-        </div>
+    <div id="results" class="results"></div>
+
+    <div id="chart-section" class="chart-section">
+        <h2>Balance Over Time</h2>
+        <canvas id="balanceChart"></canvas>
     </div>
-
-    <!-- Results -->
-    <div id="results" class="section results-section"></div>
-
-    <!-- Charts -->
-    <div id="chart-section" class="section chart-section">
-        <h2 class="section-title">Interest Paid Per Term</h2>
-        <canvas id="interestChart"></canvas>
-    </div>
-
-    <div id="pie-section" class="section chart-section">
-        <h2 class="section-title">Total Cost Breakdown</h2>
-        <canvas id="pieChart"></canvas>
-    </div>
-
-    <!-- Amortization schedule -->
-    <div id="schedule-section" class="section">
-        <h2 class="section-title">
-            Amortization Schedule
-            <div class="schedule-toggle">
-                <button id="btn-monthly" class="toggle-btn">Monthly</button>
-                <button id="btn-annual" class="toggle-btn active">Annual</button>
-            </div>
-        </h2>
-        <div class="table-wrap">
-            <table id="schedule-table">
-                <thead></thead>
-                <tbody></tbody>
-            </table>
-        </div>
-    </div>
-
-    <footer class="tool-footer">
-        <p>Nothing you enter leaves your browser. All calculations run locally. No data is sent to any server, stored in any database, or shared with third parties. Values saved in your browser&rsquo;s local storage can be cleared with the button above.</p>
-    </footer>
 
     <script src="./script.js"></script>
 </body>

--- a/static/tools/multi-term-mortgage-calculator/index.html
+++ b/static/tools/multi-term-mortgage-calculator/index.html
@@ -7,43 +7,195 @@
     <link rel="stylesheet" href="./style.css">
 </head>
 <body>
-    <h1>Multi-term Mortgage Calculator</h1>
-    <p class="subtitle">Compare mortgage terms side by side</p>
+    <!-- Hook -->
+    <div id="hook" class="hook">
+        <div class="hook-line">A <span class="hook-value" id="hook-loan">$400,000</span> mortgage costs <span class="hook-value hook-emphasis" id="hook-interest">$XXX</span> in interest alone</div>
+        <div class="hook-sub">See the full picture before you sign</div>
+    </div>
 
-    <div class="input-section">
-        <div class="field">
-            <label for="principal">Loan Amount</label>
-            <div class="input-wrap">
-                <span class="prefix">$</span>
-                <input type="number" id="principal" value="300000" min="0" step="1000">
+    <div class="header-row">
+        <div class="country-toggle">
+            <button id="btn-ca" class="country-btn active" data-country="ca">Canada</button>
+            <button id="btn-us" class="country-btn" data-country="us">United States</button>
+        </div>
+        <button id="btn-clear" class="clear-btn" title="Reset all values">Clear</button>
+    </div>
+
+    <div id="country-info" class="country-info"></div>
+
+    <!-- Core inputs: always visible -->
+    <div class="section">
+        <div class="input-row core-row">
+            <div class="field">
+                <label for="home-value">Home Value</label>
+                <div class="input-wrap">
+                    <span class="prefix">$</span>
+                    <input type="number" id="home-value" value="500000" min="0" step="1000">
+                </div>
+            </div>
+            <div class="field">
+                <label for="down-payment">Down Payment</label>
+                <div class="input-wrap">
+                    <input type="number" id="down-payment" value="100000" min="0" step="1000">
+                    <span class="suffix" id="down-pct">20%</span>
+                </div>
+            </div>
+            <div class="field">
+                <label for="loan-amount">Loan Amount</label>
+                <div class="input-wrap">
+                    <span class="prefix">$</span>
+                    <input type="number" id="loan-amount" value="400000" min="0" step="1000" readonly>
+                </div>
+            </div>
+            <div class="field">
+                <label for="amortization">Amortization</label>
+                <div class="input-wrap">
+                    <input type="number" id="amortization" value="25" min="1" max="40" step="1">
+                    <span class="suffix">yr</span>
+                </div>
             </div>
         </div>
-        <div class="field">
-            <label for="rate">Annual Interest Rate</label>
-            <div class="input-wrap">
-                <input type="number" id="rate" value="6.5" min="0" max="30" step="0.125">
-                <span class="suffix">%</span>
+        <div id="terms-list" class="terms-list"></div>
+        <button id="add-term" class="btn-link">+ Add another term</button>
+    </div>
+
+    <!-- Expandable: prepayments -->
+    <div class="section collapsible">
+        <button class="section-toggle" id="toggle-prepay">
+            <span class="section-title">Prepayments</span>
+            <span class="toggle-arrow" id="arrow-prepay"></span>
+        </button>
+        <div class="section-body collapsed" id="body-prepay">
+            <div class="input-row">
+                <div class="field">
+                    <label for="payment-increase">Increase Payment / Year</label>
+                    <div class="input-wrap">
+                        <span class="prefix">$</span>
+                        <input type="number" id="payment-increase" value="0" min="0" step="25">
+                    </div>
+                </div>
+                <div class="field">
+                    <label for="lump-sum-annual">Lump Sum / Year</label>
+                    <div class="input-wrap">
+                        <span class="prefix">$</span>
+                        <input type="number" id="lump-sum-annual" value="0" min="0" step="500">
+                    </div>
+                </div>
+                <div class="field">
+                    <label for="lump-sum-term">Lump Sum at Renewal</label>
+                    <div class="input-wrap">
+                        <span class="prefix">$</span>
+                        <input type="number" id="lump-sum-term" value="0" min="0" step="1000">
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 
-    <div class="terms-section">
-        <label>Mortgage Terms</label>
-        <div class="term-toggles">
-            <button class="term-toggle" data-term="10" aria-pressed="false">10 yr</button>
-            <button class="term-toggle active" data-term="15" aria-pressed="true">15 yr</button>
-            <button class="term-toggle active" data-term="20" aria-pressed="true">20 yr</button>
-            <button class="term-toggle active" data-term="25" aria-pressed="true">25 yr</button>
-            <button class="term-toggle active" data-term="30" aria-pressed="true">30 yr</button>
+    <!-- Expandable: recurring costs -->
+    <div class="section collapsible">
+        <button class="section-toggle" id="toggle-costs">
+            <span class="section-title">Recurring Costs</span>
+            <span class="toggle-arrow" id="arrow-costs"></span>
+        </button>
+        <div class="section-body collapsed" id="body-costs">
+            <div class="input-row">
+                <div class="field">
+                    <label for="property-tax" id="property-tax-label">Property Tax / Year</label>
+                    <div class="input-wrap">
+                        <span class="prefix">$</span>
+                        <input type="number" id="property-tax" value="3500" min="0" step="100">
+                    </div>
+                </div>
+                <div class="field">
+                    <label for="home-insurance">Home Insurance / Year</label>
+                    <div class="input-wrap">
+                        <span class="prefix">$</span>
+                        <input type="number" id="home-insurance" value="1200" min="0" step="100">
+                    </div>
+                </div>
+                <div class="field">
+                    <label for="hoa" id="hoa-label">HOA / Month</label>
+                    <div class="input-wrap">
+                        <span class="prefix">$</span>
+                        <input type="number" id="hoa" value="0" min="0" step="25">
+                    </div>
+                </div>
+            </div>
+            <div class="pmi-row" id="pmi-row" style="display:none;">
+                <div class="field">
+                    <label for="pmi" id="pmi-label">Mortgage Insurance</label>
+                    <div class="input-wrap">
+                        <input type="number" id="pmi" value="0" min="0" step="0.01">
+                        <span class="suffix">%/yr</span>
+                    </div>
+                </div>
+            </div>
+            <div class="hint" id="pmi-hint"></div>
         </div>
     </div>
 
-    <div id="results" class="results"></div>
-
-    <div id="chart-section" class="chart-section">
-        <h2>Balance Over Time</h2>
-        <canvas id="balanceChart"></canvas>
+    <!-- Expandable: start date -->
+    <div class="section collapsible">
+        <button class="section-toggle" id="toggle-date">
+            <span class="section-title">Start Date</span>
+            <span class="toggle-arrow" id="arrow-date"></span>
+        </button>
+        <div class="section-body collapsed" id="body-date">
+            <div class="input-row">
+                <div class="field">
+                    <label for="start-month">Month</label>
+                    <select id="start-month">
+                        <option value="0">January</option><option value="1">February</option><option value="2">March</option>
+                        <option value="3">April</option><option value="4">May</option><option value="5" selected>June</option>
+                        <option value="6">July</option><option value="7">August</option><option value="8">September</option>
+                        <option value="9">October</option><option value="10">November</option><option value="11">December</option>
+                    </select>
+                </div>
+                <div class="field">
+                    <label for="start-year">Year</label>
+                    <div class="input-wrap">
+                        <input type="number" id="start-year" value="2026" min="2000" max="2050" step="1">
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
+
+    <!-- Results -->
+    <div id="results" class="section results-section"></div>
+
+    <!-- Charts -->
+    <div id="chart-section" class="section chart-section">
+        <h2 class="section-title">Interest Paid Per Term</h2>
+        <canvas id="interestChart"></canvas>
+    </div>
+
+    <div id="pie-section" class="section chart-section">
+        <h2 class="section-title">Total Cost Breakdown</h2>
+        <canvas id="pieChart"></canvas>
+    </div>
+
+    <!-- Amortization schedule -->
+    <div id="schedule-section" class="section">
+        <h2 class="section-title">
+            Amortization Schedule
+            <div class="schedule-toggle">
+                <button id="btn-monthly" class="toggle-btn">Monthly</button>
+                <button id="btn-annual" class="toggle-btn active">Annual</button>
+            </div>
+        </h2>
+        <div class="table-wrap">
+            <table id="schedule-table">
+                <thead></thead>
+                <tbody></tbody>
+            </table>
+        </div>
+    </div>
+
+    <footer class="tool-footer">
+        <p>Nothing you enter leaves your browser. All calculations run locally. No data is sent to any server, stored in any database, or shared with third parties. Values saved in your browser&rsquo;s local storage can be cleared with the button above.</p>
+    </footer>
 
     <script src="./script.js"></script>
 </body>

--- a/static/tools/multi-term-mortgage-calculator/index.html
+++ b/static/tools/multi-term-mortgage-calculator/index.html
@@ -5,6 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Multi-term Mortgage Calculator</title>
     <link rel="stylesheet" href="./style.css">
+    <script>
+        (function() {
+            var q = window.matchMedia('(prefers-color-scheme: dark)');
+            var saved = localStorage.getItem('theme') || 'auto';
+            function resolve(m) { return m === 'auto' ? (q.matches ? 'dark' : 'light') : m; }
+            document.documentElement.setAttribute('data-theme', resolve(saved));
+            document.documentElement.setAttribute('data-theme-mode', saved);
+        })();
+    </script>
 </head>
 <body>
     <!-- Hook -->
@@ -18,7 +27,14 @@
             <button id="btn-ca" class="country-btn active" data-country="ca">Canada</button>
             <button id="btn-us" class="country-btn" data-country="us">United States</button>
         </div>
-        <button id="btn-clear" class="clear-btn" title="Reset all values">Clear</button>
+        <div class="header-actions">
+            <button id="theme-toggle" class="theme-toggle" title="Toggle theme">
+                <span class="theme-icon theme-icon-auto">Auto</span>
+                <span class="theme-icon theme-icon-light">Light</span>
+                <span class="theme-icon theme-icon-dark">Dark</span>
+            </button>
+            <button id="btn-clear" class="clear-btn" title="Reset all values">Clear</button>
+        </div>
     </div>
 
     <div id="country-info" class="country-info"></div>
@@ -224,6 +240,30 @@
         <p>Nothing you enter leaves your browser. All calculations run locally. No data is sent to any server, stored in any database, or shared with third parties. Values saved in your browser&rsquo;s local storage can be cleared with the button above.</p>
     </footer>
 
+    <script>
+        (function() {
+            var toggle = document.getElementById('theme-toggle');
+            var html = document.documentElement;
+            var q = window.matchMedia('(prefers-color-scheme: dark)');
+            function resolve(m) { return m === 'auto' ? (q.matches ? 'dark' : 'light') : m; }
+            function apply(m) {
+                html.setAttribute('data-theme', resolve(m));
+                html.setAttribute('data-theme-mode', m);
+            }
+            var mode = localStorage.getItem('theme') || 'auto';
+            if (toggle) {
+                toggle.addEventListener('click', function() {
+                    var modes = ['auto', 'light', 'dark'];
+                    mode = modes[(modes.indexOf(mode) + 1) % 3];
+                    localStorage.setItem('theme', mode);
+                    apply(mode);
+                });
+            }
+            q.addEventListener('change', function(e) {
+                if (mode === 'auto') html.setAttribute('data-theme', e.matches ? 'dark' : 'light');
+            });
+        })();
+    </script>
     <script src="./script.js"></script>
 </body>
 </html>

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -236,6 +236,7 @@
                 pmi: pmiInput.value,
                 startMonth: startMonthInput.value,
                 startYear: startYearInput.value,
+                scheduleMode: scheduleMode,
                 terms: terms,
             };
             localStorage.setItem(LS_KEY, JSON.stringify(state));
@@ -278,6 +279,11 @@
         if (s.pmi !== undefined) pmiInput.value = s.pmi;
         if (s.startMonth !== undefined) startMonthInput.value = s.startMonth;
         if (s.startYear !== undefined) startYearInput.value = s.startYear;
+        if (s.scheduleMode !== undefined) {
+            scheduleMode = s.scheduleMode;
+            btnMonthly.classList.toggle("active", scheduleMode === "monthly");
+            btnAnnual.classList.toggle("active", scheduleMode === "annual");
+        }
         if (s.terms && Array.isArray(s.terms) && s.terms.length > 0) {
             terms = s.terms;
         }

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -195,7 +195,7 @@
             return Math.pow(1 + semiRate, 1 / periodsPerHalfYear) - 1;
         }
         // US: monthly compounding
-        return annualRate / 100 / ppy;
+        return annualRate / 100 / schedulePaymentsPerYear(schedule);
     }
 
     function addCommas(n) {

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -444,17 +444,20 @@
             termsList.appendChild(card);
         });
 
+        var termInputHandler = function () {
+            var idx = parseInt(this.dataset.idx, 10);
+            var field = this.dataset.field;
+            if (field === "schedule") {
+                terms[idx][field] = this.value;
+            } else {
+                terms[idx][field] = parseFloat(this.value) || 0;
+            }
+            render();
+        };
+
         termsList.querySelectorAll("input, select").forEach(function (el) {
-            el.addEventListener("input", function () {
-                var idx = parseInt(el.dataset.idx, 10);
-                var field = el.dataset.field;
-                if (field === "schedule") {
-                    terms[idx][field] = el.value;
-                } else {
-                    terms[idx][field] = parseFloat(el.value) || 0;
-                }
-                render();
-            });
+            el.addEventListener("input", termInputHandler);
+            el.addEventListener("change", termInputHandler);
         });
 
         termsList.querySelectorAll(".remove-term").forEach(function (btn) {
@@ -955,7 +958,7 @@
                 "<th>Tax</th><th>Ins.</th><th>" + (country === "ca" ? "Condo" : "HOA") + "</th><th>Balance</th></tr>";
 
             var html = "";
-            var prevTerm = -1;
+            var prevTerm = yearRows.length > 0 ? yearRows[0].termIndex : -1;
             yearRows.forEach(function (r) {
                 var cls = r.termIndex !== prevTerm ? ' class="term-boundary"' : "";
                 prevTerm = r.termIndex;
@@ -978,7 +981,7 @@
                 "<th>Balance</th></tr>";
 
             var html = "";
-            var prevTerm = -1;
+            var prevTerm = rows.length > 0 ? rows[0].termIndex : -1;
             rows.forEach(function (r) {
                 var cls = r.termIndex !== prevTerm ? ' class="term-boundary"' : "";
                 prevTerm = r.termIndex;

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -1,102 +1,727 @@
 (function () {
-    var principalInput = document.getElementById("principal");
-    var rateInput = document.getElementById("rate");
+    // --- DOM refs ---
+    var homeValueInput = document.getElementById("home-value");
+    var downPaymentInput = document.getElementById("down-payment");
+    var loanAmountInput = document.getElementById("loan-amount");
+    var downPctEl = document.getElementById("down-pct");
+    var amortInput = document.getElementById("amortization");
+    var paymentIncreaseInput = document.getElementById("payment-increase");
+    var lumpSumAnnualInput = document.getElementById("lump-sum-annual");
+    var lumpSumTermInput = document.getElementById("lump-sum-term");
+    var propertyTaxInput = document.getElementById("property-tax");
+    var homeInsuranceInput = document.getElementById("home-insurance");
+    var hoaInput = document.getElementById("hoa");
+    var pmiInput = document.getElementById("pmi");
+    var pmiRow = document.getElementById("pmi-row");
+    var pmiHint = document.getElementById("pmi-hint");
+    var pmiLabel = document.getElementById("pmi-label");
+    var hoaLabel = document.getElementById("hoa-label");
+    var propertyTaxLabel = document.getElementById("property-tax-label");
+    var startMonthInput = document.getElementById("start-month");
+    var startYearInput = document.getElementById("start-year");
+    var termsList = document.getElementById("terms-list");
+    var addTermBtn = document.getElementById("add-term");
     var resultsEl = document.getElementById("results");
     var chartSection = document.getElementById("chart-section");
-    var toggleButtons = document.querySelectorAll(".term-toggle");
+    var pieSection = document.getElementById("pie-section");
+    var scheduleSection = document.getElementById("schedule-section");
+    var scheduleTableBody = document.querySelector("#schedule-table tbody");
+    var scheduleTableHead = document.querySelector("#schedule-table thead");
+    var btnMonthly = document.getElementById("btn-monthly");
+    var btnAnnual = document.getElementById("btn-annual");
+    var btnCA = document.getElementById("btn-ca");
+    var btnUS = document.getElementById("btn-us");
+    var countryInfoEl = document.getElementById("country-info");
+    var btnClear = document.getElementById("btn-clear");
+    var hookLoan = document.getElementById("hook-loan");
+    var hookInterest = document.getElementById("hook-interest");
 
-    var colors = [
-        { line: "#e74c3c", bg: "rgba(231,76,60,0.10)" },
-        { line: "#3498db", bg: "rgba(52,152,219,0.10)" },
-        { line: "#2ecc71", bg: "rgba(46,204,113,0.10)" },
-        { line: "#f39c12", bg: "rgba(243,156,18,0.10)" },
-        { line: "#9b59b6", bg: "rgba(155,89,182,0.10)" },
-    ];
+    // Collapsible sections
+    var collapsibles = {
+        prepay: { toggle: document.getElementById("toggle-prepay"), body: document.getElementById("body-prepay"), arrow: document.getElementById("arrow-prepay") },
+        costs:  { toggle: document.getElementById("toggle-costs"),  body: document.getElementById("body-costs"),  arrow: document.getElementById("arrow-arrow-costs") },
+        date:   { toggle: document.getElementById("toggle-date"),   body: document.getElementById("body-date"),   arrow: document.getElementById("arrow-date") },
+    };
+    // Fix arrow-costs id
+    collapsibles.costs.arrow = document.getElementById("arrow-costs");
 
-    function getActiveTerms() {
-        var terms = [];
-        toggleButtons.forEach(function (btn) {
-            if (btn.classList.contains("active")) {
-                terms.push(parseInt(btn.dataset.term, 10));
-            }
+    // Collapsible toggle handlers
+    Object.keys(collapsibles).forEach(function (key) {
+        var c = collapsibles[key];
+        c.toggle.addEventListener("click", function () {
+            var isOpen = !c.body.classList.contains("collapsed");
+            c.body.classList.toggle("collapsed", isOpen);
+            c.arrow.classList.toggle("open", !isOpen);
+            saveCollapsedState();
         });
-        return terms.sort(function (a, b) { return a - b; });
+    });
+
+    function saveCollapsedState() {
+        try {
+            var state = {};
+            Object.keys(collapsibles).forEach(function (key) {
+                state[key] = collapsibles[key].body.classList.contains("collapsed");
+            });
+            localStorage.setItem(LS_KEY + "-collapsed", JSON.stringify(state));
+        } catch (e) {}
     }
 
-    function calcMonthly(principal, annualRate, years) {
-        if (principal <= 0 || years <= 0) return 0;
-        if (annualRate === 0) return principal / (years * 12);
-        var r = annualRate / 100 / 12;
-        var n = years * 12;
+    function loadCollapsedState() {
+        try {
+            var raw = localStorage.getItem(LS_KEY + "-collapsed");
+            if (!raw) return;
+            var state = JSON.parse(raw);
+            Object.keys(state).forEach(function (key) {
+                if (collapsibles[key]) {
+                    collapsibles[key].body.classList.toggle("collapsed", state[key]);
+                    collapsibles[key].arrow.classList.toggle("open", !state[key]);
+                }
+            });
+        } catch (e) {}
+    }
+
+    var countryInfo = {
+        ca: {
+            bullets: [
+                "<strong>Semi-annual compounding.</strong> Interest compounds twice a year, so the effective monthly rate is lower than rate/12.",
+                "<strong>CMHC default insurance</strong> required when down payment is under 20%. Premium is a one-time cost (0.6% to 4% of loan) added to the mortgage.",
+                "<strong>Term vs amortization.</strong> Typical terms are 1-5 years at a fixed rate; the amortization is 25-30 years. Rate renegotiated at each renewal.",
+                "<strong>Prepayment limits.</strong> Most lenders allow 10-20% lump sum per year and payment increases up to double. Penalties apply beyond that.",
+            ],
+        },
+        us: {
+            bullets: [
+                "<strong>Monthly compounding.</strong> Interest is calculated at rate/12 each month. The quoted rate equals the effective rate.",
+                "<strong>PMI</strong> required when down payment is under 20%. Ongoing monthly cost that cancels automatically at 78-80% LTV.",
+                "<strong>30-year fixed</strong> is the most common mortgage. You lock the rate for the entire loan. No renewals.",
+                "<strong>HOA</strong> (Homeowners Association) fees are common for condos and planned communities. Typically paid monthly.",
+            ],
+        },
+    };
+
+    var termColors = ["#111", "#4a4a4a", "#7a7a7a", "#a5a5a5", "#c5c5c5", "#333", "#5a5a5a", "#8a8a8a"];
+    var pieColors = ["#111", "#4a4a4a", "#7a7a7a", "#a5a5a5", "#c5c5c5", "#ddd"];
+    var monthNames = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+
+    // --- Country presets ---
+    var countryConfig = {
+        ca: {
+            defaultAmort: 25,
+            maxAmort: 30,
+            defaultTerms: [
+                { years: 5, rate: 4.99, schedule: "monthly" },
+                { years: 5, rate: 4.49, schedule: "monthly" },
+                { years: 5, rate: 4.19, schedule: "monthly" },
+                { years: 5, rate: 3.99, schedule: "monthly" },
+                { years: 5, rate: 3.79, schedule: "monthly" },
+            ],
+            compounding: "semi-annual", // Canadian fixed mortgages compound semi-annually
+            insuranceLabel: "Default Insurance (CMHC)",
+            hoaLabel: "Condo Fees / Month",
+            taxLabel: "Property Tax / Year",
+            newTermDuration: 5,
+            pmiEstimate: function (downPct) {
+                // CMHC rates: 4% for 5-9.99%, 3.1% for 10-14.99%, 2.4% for 15-19.99%
+                if (downPct < 5) return 4.0;
+                if (downPct < 10) return 3.1;
+                if (downPct < 15) return 2.4;
+                if (downPct < 20) return 1.8;
+                return 0;
+            },
+            pmiIsUpfront: true, // CMHC is a one-time premium added to loan
+        },
+        us: {
+            defaultAmort: 30,
+            maxAmort: 40,
+            defaultTerms: [
+                { years: 30, rate: 6.5, schedule: "monthly" },
+            ],
+            compounding: "monthly",
+            insuranceLabel: "PMI",
+            hoaLabel: "HOA / Month",
+            taxLabel: "Property Tax / Year",
+            newTermDuration: 5,
+            pmiEstimate: function (downPct) {
+                if (downPct < 5) return 1.5;
+                if (downPct < 10) return 1.0;
+                if (downPct < 15) return 0.6;
+                if (downPct < 20) return 0.3;
+                return 0;
+            },
+            pmiIsUpfront: false, // PMI is ongoing monthly
+        },
+    };
+
+    var country = "ca";
+    var terms = [];
+    var scheduleMode = "annual";
+    var lastSimResult = null;
+    var LS_KEY = "mortgage-calc-v1";
+
+    // --- Helpers ---
+
+    function schedulePaymentsPerYear(schedule) {
+        if (schedule === "biweekly") return 26;
+        if (schedule === "weekly") return 52;
+        return 12;
+    }
+
+    function scheduleLabel(schedule) {
+        if (schedule === "biweekly") return "bi-weekly";
+        if (schedule === "weekly") return "weekly";
+        return "monthly";
+    }
+
+    // Canadian mortgage: effective monthly rate from semi-annual compounding
+    // rate_semi = annualRate/2, effective monthly = (1 + rate_semi)^^(2/12) - 1
+    function effectiveMonthlyRate(annualRate, compounding) {
+        if (compounding === "semi-annual") {
+            var semiRate = annualRate / 100 / 2;
+            return Math.pow(1 + semiRate, 1 / 6) - 1;
+        }
+        // US: monthly compounding
+        return annualRate / 100 / 12;
+    }
+
+    function calcBasePayment(principal, annualRate, amortYears, schedule, compounding) {
+        var ppy = schedulePaymentsPerYear(schedule);
+        var n = amortYears * ppy;
+        if (principal <= 0 || n <= 0) return 0;
+
+        var r;
+        if (compounding === "semi-annual") {
+            // For Canadian mortgages, convert to effective period rate
+            var monthlyRate = effectiveMonthlyRate(annualRate, "semi-annual");
+            if (schedule === "monthly") {
+                r = monthlyRate;
+            } else if (schedule === "biweekly") {
+                r = Math.pow(1 + monthlyRate, 1 / 2) - 1;
+            } else {
+                r = Math.pow(1 + monthlyRate, 1 / 4) - 1;
+            }
+        } else {
+            r = annualRate / 100 / ppy;
+        }
+
+        if (r === 0) return principal / n;
         return principal * (r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1);
     }
 
-    function calcAmortization(principal, annualRate, years) {
-        var monthly = calcMonthly(principal, annualRate, years);
-        var r = annualRate / 100 / 12;
-        var n = years * 12;
-        var totalPaid = monthly * n;
-        var totalInterest = totalPaid - principal;
+    function addCommas(n) {
+        var parts = n.toString().split(".");
+        parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+        return parts.join(".");
+    }
 
-        // Yearly balances for chart
-        var balances = [principal];
-        var balance = principal;
-        for (var y = 1; y <= years; y++) {
-            for (var m = 0; m < 12; m++) {
-                var interest = balance * r;
-                balance = balance - (monthly - interest);
-                if (balance < 0) balance = 0;
-            }
-            balances.push(Math.round(balance * 100) / 100);
+    function fmt(val) {
+        return "$" + addCommas(Math.round(val));
+    }
+
+    function fmtFull(val) {
+        var rounded = Math.round(val * 100) / 100;
+        var parts = rounded.toFixed(2).split(".");
+        return "$" + addCommas(parseInt(parts[0])) + "." + parts[1];
+    }
+
+    function fmtPct(val) {
+        return val.toFixed(1) + "%";
+    }
+
+    function fmtShort(val) {
+        if (Math.abs(val) >= 1000000) {
+            return "$" + (val / 1000000).toFixed(1) + "M";
+        }
+        return fmt(val);
+    }
+
+    // --- Local storage ---
+
+    function saveState() {
+        try {
+            var state = {
+                country: country,
+                homeValue: homeValueInput.value,
+                downPayment: downPaymentInput.value,
+                amortization: amortInput.value,
+                paymentIncrease: paymentIncreaseInput.value,
+                lumpSumAnnual: lumpSumAnnualInput.value,
+                lumpSumTerm: lumpSumTermInput.value,
+                propertyTax: propertyTaxInput.value,
+                homeInsurance: homeInsuranceInput.value,
+                hoa: hoaInput.value,
+                pmi: pmiInput.value,
+                startMonth: startMonthInput.value,
+                startYear: startYearInput.value,
+                terms: terms,
+            };
+            localStorage.setItem(LS_KEY, JSON.stringify(state));
+        } catch (e) { /* storage full or unavailable */ }
+    }
+
+    function loadState() {
+        try {
+            var raw = localStorage.getItem(LS_KEY);
+            if (!raw) return null;
+            return JSON.parse(raw);
+        } catch (e) { return null; }
+    }
+
+    function clearState() {
+        try { localStorage.removeItem(LS_KEY); } catch (e) {}
+    }
+
+    function applyState(s) {
+        if (!s) return false;
+        if (s.country && countryConfig[s.country]) {
+            country = s.country;
+            btnCA.classList.toggle("active", country === "ca");
+            btnUS.classList.toggle("active", country === "us");
+            var cfg = countryConfig[country];
+            pmiLabel.textContent = cfg.insuranceLabel;
+            hoaLabel.textContent = cfg.hoaLabel;
+            propertyTaxLabel.textContent = cfg.taxLabel;
+            amortInput.max = cfg.maxAmort;
+        }
+        if (s.homeValue !== undefined) homeValueInput.value = s.homeValue;
+        if (s.downPayment !== undefined) downPaymentInput.value = s.downPayment;
+        if (s.amortization !== undefined) amortInput.value = s.amortization;
+        if (s.paymentIncrease !== undefined) paymentIncreaseInput.value = s.paymentIncrease;
+        if (s.lumpSumAnnual !== undefined) lumpSumAnnualInput.value = s.lumpSumAnnual;
+        if (s.lumpSumTerm !== undefined) lumpSumTermInput.value = s.lumpSumTerm;
+        if (s.propertyTax !== undefined) propertyTaxInput.value = s.propertyTax;
+        if (s.homeInsurance !== undefined) homeInsuranceInput.value = s.homeInsurance;
+        if (s.hoa !== undefined) hoaInput.value = s.hoa;
+        if (s.pmi !== undefined) pmiInput.value = s.pmi;
+        if (s.startMonth !== undefined) startMonthInput.value = s.startMonth;
+        if (s.startYear !== undefined) startYearInput.value = s.startYear;
+        if (s.terms && Array.isArray(s.terms) && s.terms.length > 0) {
+            terms = s.terms;
+        }
+        renderCountryInfo();
+        return true;
+    }
+
+    function renderCountryInfo() {
+        var info = countryInfo[country];
+        if (!info) { countryInfoEl.innerHTML = ""; return; }
+        var html = "<ul>";
+        info.bullets.forEach(function (b) { html += "<li>" + b + "</li>"; });
+        html += "</ul>";
+        countryInfoEl.innerHTML = html;
+    }
+
+    // --- Country switching ---
+
+    function switchCountry(c) {
+        country = c;
+        btnCA.classList.toggle("active", c === "ca");
+        btnUS.classList.toggle("active", c === "us");
+
+        var cfg = countryConfig[country];
+
+        // Update labels
+        pmiLabel.textContent = cfg.insuranceLabel;
+        hoaLabel.textContent = cfg.hoaLabel;
+        propertyTaxLabel.textContent = cfg.taxLabel;
+
+        // Update amortization
+        amortInput.max = cfg.maxAmort;
+        amortInput.value = cfg.defaultAmort;
+
+        // Reset terms to country defaults
+        terms = cfg.defaultTerms.map(function (t) { return { years: t.years, rate: t.rate, schedule: t.schedule }; });
+
+        // Reset PMI — syncLoan will re-estimate based on new country
+        pmiInput.value = 0;
+
+        // Set country-specific defaults for recurring costs
+        if (c === "ca") {
+            propertyTaxInput.value = 3500;
+            homeInsuranceInput.value = 1200;
+            hoaInput.value = 0;
+        } else {
+            propertyTaxInput.value = 5500;
+            homeInsuranceInput.value = 2000;
+            hoaInput.value = 0;
         }
 
-        return { monthly: monthly, totalPaid: totalPaid, totalInterest: totalInterest, balances: balances, years: years };
+        renderTerms();
+        syncLoan();
+        render();
+        renderCountryInfo();
+
+        // Auto-expand recurring costs if insurance is relevant
+        var downPct = (parseFloat(homeValueInput.value) || 0) > 0
+            ? (parseFloat(downPaymentInput.value) || 0) / (parseFloat(homeValueInput.value) || 0) * 100
+            : 100;
+        if (downPct < 20) {
+            collapsibles.costs.body.classList.remove("collapsed");
+            collapsibles.costs.arrow.classList.add("open");
+        }
+
+        saveState();
     }
 
-    function formatCurrency(val) {
-        return "$" + val.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+    btnCA.addEventListener("click", function () { switchCountry("ca"); });
+    btnUS.addEventListener("click", function () { switchCountry("us"); });
+
+    // --- Down payment / loan amount sync ---
+
+    function syncLoan() {
+        var hv = parseFloat(homeValueInput.value) || 0;
+        var dp = parseFloat(downPaymentInput.value) || 0;
+        if (dp > hv) {
+            dp = hv;
+            downPaymentInput.value = dp;
+        }
+        var loan = hv - dp;
+        var cfg = countryConfig[country];
+
+        // Canada: CMHC premium added to loan if down payment < 20%
+        var cmhcPremium = 0;
+        if (country === "ca" && loan > 0) {
+            var downPct = hv > 0 ? dp / hv * 100 : 0;
+            if (downPct < 20) {
+                var cmhcRate = cfg.pmiEstimate(downPct);
+                cmhcPremium = loan * cmhcRate / 100;
+                // CMHC premium can be added to the mortgage
+                loan += cmhcPremium;
+            }
+        }
+
+        loanAmountInput.value = Math.round(loan);
+        var pct = hv > 0 ? (dp / hv * 100) : 0;
+        downPctEl.textContent = pct.toFixed(0) + "%";
+
+        // Insurance visibility
+        if (pct < 20 && (hv - dp) > 0) {
+            pmiRow.style.display = "block";
+            if (country === "ca") {
+                if (parseFloat(pmiInput.value) === 0) {
+                    pmiInput.value = cfg.pmiEstimate(pct);
+                }
+                pmiHint.textContent = "CMHC premium of " + fmt(cmhcPremium) + " added to loan. Down payment under 20% requires default insurance.";
+            } else {
+                if (parseFloat(pmiInput.value) === 0) {
+                    pmiInput.value = cfg.pmiEstimate(pct);
+                }
+                pmiHint.textContent = "Down payment under 20%: PMI typically required until 78-80% LTV. Adjust rate as needed.";
+            }
+        } else {
+            pmiRow.style.display = "none";
+            pmiHint.textContent = "";
+        }
     }
 
-    function formatCurrencyFull(val) {
-        return "$" + val.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    homeValueInput.addEventListener("input", syncLoan);
+    downPaymentInput.addEventListener("input", syncLoan);
+
+    // --- Term UI ---
+
+    function renderTerms() {
+        termsList.innerHTML = "";
+        terms.forEach(function (term, i) {
+            var maxDuration = country === "ca" ? 10 : 40;
+            var card = document.createElement("div");
+            card.className = "term-card";
+            card.innerHTML =
+                '<div class="term-card-header">' +
+                '<h3>Term ' + (i + 1) + '</h3>' +
+                (terms.length > 1 ? '<button class="remove-term" data-idx="' + i + '" title="Remove term">&times;</button>' : '') +
+                '</div>' +
+                '<div class="term-fields">' +
+                '<div class="field"><label>Duration</label><div class="input-wrap"><input type="number" data-idx="' + i + '" data-field="years" value="' + term.years + '" min="1" max="' + maxDuration + '" step="1"><span class="suffix">yr</span></div></div>' +
+                '<div class="field"><label>Rate</label><div class="input-wrap"><input type="number" data-idx="' + i + '" data-field="rate" value="' + term.rate + '" min="0" max="30" step="0.01"><span class="suffix">%</span></div></div>' +
+                '<div class="field"><label>Schedule</label><select data-idx="' + i + '" data-field="schedule"><option value="monthly"' + (term.schedule === "monthly" ? " selected" : "") + '>Monthly</option><option value="biweekly"' + (term.schedule === "biweekly" ? " selected" : "") + '>Bi-weekly</option><option value="weekly"' + (term.schedule === "weekly" ? " selected" : "") + '>Weekly</option></select></div>' +
+                '</div>';
+            termsList.appendChild(card);
+        });
+
+        termsList.querySelectorAll("input, select").forEach(function (el) {
+            el.addEventListener("input", function () {
+                var idx = parseInt(el.dataset.idx, 10);
+                var field = el.dataset.field;
+                if (field === "schedule") {
+                    terms[idx][field] = el.value;
+                } else {
+                    terms[idx][field] = parseFloat(el.value) || 0;
+                }
+                render();
+            });
+        });
+
+        termsList.querySelectorAll(".remove-term").forEach(function (btn) {
+            btn.addEventListener("click", function () {
+                terms.splice(parseInt(btn.dataset.idx, 10), 1);
+                renderTerms();
+                render();
+            });
+        });
     }
+
+    addTermBtn.addEventListener("click", function () {
+        var cfg = countryConfig[country];
+        var lastRate = terms.length > 0 ? terms[terms.length - 1].rate : 5;
+        terms.push({ years: cfg.newTermDuration, rate: Math.max(0.5, lastRate - 0.2), schedule: "monthly" });
+        renderTerms();
+        render();
+    });
+
+    // --- Simulation ---
+
+    function simulateMortgage(principal, amortYears, termDefs, annualIncrease, lumpAnnual, lumpTerm, annualTax, annualInsurance, monthlyHOA, annualPMI, startMonth, startYear) {
+        var balance = principal;
+        var remainingAmort = amortYears;
+        var totalInterest = 0;
+        var totalPrincipalPaid = 0;
+        var totalTax = 0;
+        var totalInsurance = 0;
+        var totalHOA = 0;
+        var totalPMI = 0;
+        var termResults = [];
+        var schedule = [];
+        var currentYear = 0;
+        var globalMonth = 0;
+        var compounding = countryConfig[country].compounding;
+        var pmiIsOngoing = country === "us"; // US: ongoing PMI, CA: upfront CMHC (already in loan)
+
+        for (var ti = 0; ti < termDefs.length && balance > 0.01; ti++) {
+            var term = termDefs[ti];
+            var ppy = schedulePaymentsPerYear(term.schedule);
+
+            // Effective period rate
+            var r;
+            if (compounding === "semi-annual") {
+                var monthlyRate = effectiveMonthlyRate(term.rate, "semi-annual");
+                if (term.schedule === "monthly") {
+                    r = monthlyRate;
+                } else if (term.schedule === "biweekly") {
+                    r = Math.pow(1 + monthlyRate, 1 / 2) - 1;
+                } else {
+                    r = Math.pow(1 + monthlyRate, 1 / 4) - 1;
+                }
+            } else {
+                r = term.rate / 100 / ppy;
+            }
+
+            var termPayments = term.years * ppy;
+
+            var basePayment = calcBasePayment(balance, term.rate, remainingAmort, term.schedule, compounding);
+            var payment = basePayment;
+            var yearInMortgage = currentYear;
+            var paymentsThisYear = 0;
+            var termPrincipal = 0;
+            var termInterest = 0;
+            var termTax = 0;
+            var termInsurance = 0;
+            var termHOA = 0;
+            var termPMI = 0;
+
+            for (var p = 0; p < termPayments && balance > 0.01; p++) {
+                // Annual payment increase
+                if (p > 0 && p % ppy === 0) {
+                    payment += annualIncrease;
+                    yearInMortgage++;
+                    paymentsThisYear = 0;
+                }
+
+                var interestPortion = balance * r;
+                var principalPortion = payment - interestPortion;
+                if (principalPortion > balance) {
+                    principalPortion = balance;
+                }
+
+                // PMI (US only: ongoing until 78-80% LTV)
+                var pmiPortion = 0;
+                if (pmiIsOngoing) {
+                    var downPct = principal > 0 ? ((parseFloat(homeValueInput.value) - balance) / parseFloat(homeValueInput.value) * 100) : 100;
+                    if (downPct < 20) {
+                        pmiPortion = (annualPMI / 100 * balance) / ppy;
+                    }
+                }
+
+                balance -= principalPortion;
+                termPrincipal += principalPortion;
+                termInterest += interestPortion;
+                termPMI += pmiPortion;
+
+                paymentsThisYear++;
+
+                // Schedule row
+                var absMonth = (startMonth + globalMonth) % 12;
+                var absYear = startYear + Math.floor((startMonth + globalMonth) / 12);
+                schedule.push({
+                    month: absMonth,
+                    year: absYear,
+                    termIndex: ti,
+                    payment: principalPortion + interestPortion + pmiPortion,
+                    principal: principalPortion,
+                    interest: interestPortion,
+                    pmi: pmiPortion,
+                    tax: annualTax / ppy,
+                    insurance: annualInsurance / ppy,
+                    hoa: monthlyHOA * 12 / ppy,
+                    balance: Math.max(0, balance),
+                });
+
+                globalMonth++;
+
+                // Annual lump sum
+                if (lumpAnnual > 0 && paymentsThisYear === ppy && balance > 0.01) {
+                    var lumpApply = Math.min(lumpAnnual, balance);
+                    balance -= lumpApply;
+                    termPrincipal += lumpApply;
+                }
+            }
+
+            // Lump sum at renewal
+            if (lumpTerm > 0 && balance > 0.01) {
+                var lumpApplyTerm = Math.min(lumpTerm, balance);
+                balance -= lumpApplyTerm;
+                termPrincipal += lumpApplyTerm;
+            }
+
+            var termYears = term.years;
+            termTax = annualTax * termYears;
+            termInsurance = annualInsurance * termYears;
+            termHOA = monthlyHOA * 12 * termYears;
+
+            totalInterest += termInterest;
+            totalPrincipalPaid += termPrincipal;
+            totalTax += termTax;
+            totalInsurance += termInsurance;
+            totalHOA += termHOA;
+            totalPMI += termPMI;
+
+            remainingAmort -= term.years;
+            if (remainingAmort < 1) remainingAmort = 1;
+
+            var insuranceLabel = country === "ca" ? "CMHC" : "PMI";
+
+            termResults.push({
+                index: ti,
+                years: term.years,
+                rate: term.rate,
+                schedule: term.schedule,
+                basePayment: basePayment,
+                principalPaid: termPrincipal,
+                interestPaid: termInterest,
+                balanceAtEnd: balance,
+                totalPayments: termPrincipal + termInterest,
+                tax: termTax,
+                insurance: termInsurance,
+                hoa: termHOA,
+                pmi: termPMI,
+                pmiLabel: insuranceLabel,
+            });
+
+            currentYear += term.years;
+        }
+
+        return {
+            totalInterest: totalInterest,
+            totalPrincipalPaid: totalPrincipalPaid,
+            totalPaid: totalInterest + totalPrincipalPaid,
+            totalTax: totalTax,
+            totalInsurance: totalInsurance,
+            totalHOA: totalHOA,
+            totalPMI: totalPMI,
+            totalAllIn: totalPrincipalPaid + totalInterest + totalTax + totalInsurance + totalHOA + totalPMI,
+            termResults: termResults,
+            schedule: schedule,
+            paidOff: balance < 0.01,
+            principal: principal,
+            pmiLabel: country === "ca" ? "Default Ins." : "PMI",
+        };
+    }
+
+    // --- Results rendering ---
 
     function render() {
-        var principal = parseFloat(principalInput.value) || 0;
-        var rate = parseFloat(rateInput.value) || 0;
-        var terms = getActiveTerms();
+        var principal = parseFloat(loanAmountInput.value) || 0;
+        var amort = parseInt(amortInput.value, 10) || 25;
+        var annualIncrease = parseFloat(paymentIncreaseInput.value) || 0;
+        var lumpAnnual = parseFloat(lumpSumAnnualInput.value) || 0;
+        var lumpTerm = parseFloat(lumpSumTermInput.value) || 0;
+        var annualTax = parseFloat(propertyTaxInput.value) || 0;
+        var annualInsurance = parseFloat(homeInsuranceInput.value) || 0;
+        var monthlyHOA = parseFloat(hoaInput.value) || 0;
+        var annualPMI = parseFloat(pmiInput.value) || 0;
+        var startMonth = parseInt(startMonthInput.value, 10) || 0;
+        var startYear = parseInt(startYearInput.value, 10) || 2026;
 
-        if (terms.length === 0) {
-            resultsEl.innerHTML = '<p class="hint">Select at least one term to compare.</p>';
-            chartSection.style.display = "none";
+        if (principal <= 0 || terms.length === 0) {
+            resultsEl.classList.remove("visible");
+            chartSection.classList.remove("visible");
+            pieSection.classList.remove("visible");
+            scheduleSection.style.display = "none";
             return;
         }
 
-        var results = terms.map(function (t) {
-            return calcAmortization(principal, rate, t);
-        });
+        var sim = simulateMortgage(principal, amort, terms, annualIncrease, lumpAnnual, lumpTerm, annualTax, annualInsurance, monthlyHOA, annualPMI, startMonth, startYear);
+        lastSimResult = sim;
 
-        // Cards
-        resultsEl.innerHTML = results.map(function (r, i) {
-            var years = r.years;
-            return '<div class="result-card">' +
-                '<h3>' + years + '-Year Fixed</h3>' +
-                '<div class="monthly">' + formatCurrencyFull(r.monthly) + ' <span>/mo</span></div>' +
-                '<dl class="result-details">' +
-                '<div><dt>Total Interest</dt><dd>' + formatCurrency(r.totalInterest) + '</dd></div>' +
-                '<div><dt>Total Paid</dt><dd>' + formatCurrency(r.totalPaid) + '</dd></div>' +
-                '<div><dt>Interest %</dt><dd>' + (r.totalPaid > 0 ? (r.totalInterest / r.totalPaid * 100).toFixed(1) : 0) + '%</dd></div>' +
+        // Update hook
+        hookLoan.textContent = fmt(principal);
+        hookInterest.textContent = fmt(sim.totalInterest);
+
+        // Summary
+        var html =
+            '<div class="result-summary">' +
+            '<div class="summary-card"><div class="label">Total Cost (All-In)</div><div class="value">' + fmt(sim.totalAllIn) + '</div></div>' +
+            '<div class="summary-card"><div class="label">Total Interest</div><div class="value">' + fmt(sim.totalInterest) + '</div></div>' +
+            '<div class="summary-card accent"><div class="label">Interest / Payments</div><div class="value">' + fmtPct(sim.totalPaid > 0 ? sim.totalInterest / sim.totalPaid * 100 : 0) + '</div></div>' +
+            '</div>';
+
+        // Bi-weekly comparison
+        var firstTerm = sim.termResults[0];
+        if (firstTerm && firstTerm.schedule === "monthly") {
+            var monthlyPay = firstTerm.basePayment;
+            var biweeklyPay = monthlyPay / 2;
+            var biweeklyAnnual = biweeklyPay * 26;
+            var monthlyAnnual = monthlyPay * 12;
+            var extraPerYear = biweeklyAnnual - monthlyAnnual;
+            html += '<div class="biweekly-compare">Switch to bi-weekly payments of <strong>' + fmtFull(biweeklyPay) + '</strong>? That equals <strong>' + fmt(extraPerYear) + ' extra/year</strong> going to principal, cutting years off your mortgage.</div>';
+        }
+
+        // Per-term breakdown
+        sim.termResults.forEach(function (tr, i) {
+            html +=
+                '<div class="term-result">' +
+                '<h4>Term ' + (i + 1) + ' &mdash; ' + tr.years + ' yr @ ' + tr.rate + '% (' + scheduleLabel(tr.schedule) + ')</h4>' +
+                '<dl class="term-result-grid">' +
+                '<div><dt>Payment</dt><dd>' + fmtFull(tr.basePayment) + '</dd></div>' +
+                '<div><dt>Principal Paid</dt><dd>' + fmt(tr.principalPaid) + '</dd></div>' +
+                '<div><dt>Interest Paid</dt><dd>' + fmt(tr.interestPaid) + '</dd></div>' +
+                '<div><dt>Total P&I</dt><dd>' + fmt(tr.totalPayments) + '</dd></div>' +
+                '<div><dt>Balance at End</dt><dd>' + fmt(tr.balanceAtEnd) + '</dd></div>' +
+                '<div><dt>Interest Share</dt><dd>' + fmtPct(tr.totalPayments > 0 ? tr.interestPaid / tr.totalPayments * 100 : 0) + '</dd></div>' +
+                (tr.pmi > 0 ? '<div><dt>' + tr.pmiLabel + '</dt><dd>' + fmt(tr.pmi) + '</dd></div>' : '') +
                 '</dl>' +
                 '</div>';
-        }).join("");
+        });
 
-        // Chart
-        chartSection.style.display = "block";
-        drawChart(results);
+        if (!sim.paidOff) {
+            html += '<p class="hint" style="margin-top:0.5rem;color:#c0392b;font-size:0.8125rem;font-weight:600;">Mortgage not fully paid after all terms. Remaining balance: ' + fmt(sim.termResults[sim.termResults.length - 1].balanceAtEnd) + '</p>';
+        }
+
+        resultsEl.innerHTML = html;
+        resultsEl.classList.add("visible");
+
+        drawInterestChart(sim);
+        chartSection.classList.add("visible");
+
+        drawPieChart(sim);
+        pieSection.classList.add("visible");
+
+        renderSchedule(sim);
+        saveState();
     }
 
-    function drawChart(results) {
-        var canvas = document.getElementById("balanceChart");
+    // --- Interest per term bar chart ---
+
+    function drawInterestChart(sim) {
+        var canvas = document.getElementById("interestChart");
         var dpr = window.devicePixelRatio || 1;
         var rect = canvas.getBoundingClientRect();
         canvas.width = rect.width * dpr;
@@ -106,20 +731,30 @@
 
         var W = rect.width;
         var H = rect.height;
-        var pad = { top: 20, right: 20, bottom: 35, left: 65 };
+        var pad = { top: 25, right: 20, bottom: 40, left: 60 };
         var plotW = W - pad.left - pad.right;
         var plotH = H - pad.top - pad.bottom;
 
         ctx.clearRect(0, 0, W, H);
 
-        var maxYears = Math.max.apply(null, results.map(function (r) { return r.years; }));
-        var maxBalance = Math.max.apply(null, results.map(function (r) { return r.balances[0]; })) || 1;
+        var tr = sim.termResults;
+        if (tr.length === 0) return;
 
-        // Grid lines
-        ctx.strokeStyle = "#e0e0e0";
+        var maxInterest = 0;
+        tr.forEach(function (t) { if (t.interestPaid > maxInterest) maxInterest = t.interestPaid; });
+        if (maxInterest === 0) return;
+
+        var niceMax = Math.ceil(maxInterest / 5000) * 5000;
+        if (niceMax === 0) niceMax = 5000;
+
+        var barGroupWidth = plotW / tr.length;
+        var barWidth = Math.min(barGroupWidth * 0.55, 60);
+
+        // Grid
+        ctx.strokeStyle = "#e2e2e2";
         ctx.lineWidth = 1;
-        ctx.font = "11px system-ui, sans-serif";
-        ctx.fillStyle = "#999";
+        ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
+        ctx.fillStyle = "#888";
         ctx.textAlign = "right";
         ctx.textBaseline = "middle";
 
@@ -129,87 +764,286 @@
             ctx.moveTo(pad.left, y);
             ctx.lineTo(pad.left + plotW, y);
             ctx.stroke();
-            var val = maxBalance * (1 - g / 4);
-            ctx.fillText(formatCurrency(val), pad.left - 8, y);
+            var val = niceMax * (1 - g / 4);
+            ctx.fillText(fmt(val), pad.left - 6, y);
         }
 
-        // X axis labels
-        ctx.textAlign = "center";
-        ctx.textBaseline = "top";
-        var xSteps = Math.min(maxYears, 6);
-        for (var x = 0; x <= xSteps; x++) {
-            var year = Math.round(maxYears / xSteps * x);
-            var xp = pad.left + (year / maxYears) * plotW;
-            ctx.fillText(year + "yr", xp, pad.top + plotH + 8);
-        }
+        // Bars
+        tr.forEach(function (t, i) {
+            var cx = pad.left + barGroupWidth * i + barGroupWidth / 2;
+            var x = cx - barWidth / 2;
+            var bHeight = (t.interestPaid / niceMax) * plotH;
 
-        // Lines
-        results.forEach(function (r, i) {
-            var color = colors[i % colors.length];
-            ctx.strokeStyle = color.line;
-            ctx.lineWidth = 2.5;
-            ctx.beginPath();
+            ctx.fillStyle = termColors[i % termColors.length];
+            ctx.fillRect(x, pad.top + plotH - bHeight, barWidth, bHeight);
 
-            var step = maxYears / 60; // ~60 data points for longest
-            for (var t = 0; t <= r.years; t++) {
-                var xp = pad.left + (t / maxYears) * plotW;
-                var yp = pad.top + (1 - r.balances[t] / maxBalance) * plotH;
-                if (t === 0) ctx.moveTo(xp, yp);
-                else ctx.lineTo(xp, yp);
-            }
-            ctx.stroke();
+            // Value on top
+            ctx.fillStyle = "#555";
+            ctx.textAlign = "center";
+            ctx.textBaseline = "bottom";
+            ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
+            ctx.fillText(fmt(t.interestPaid), cx, pad.top + plotH - bHeight - 4);
 
-            // Light fill
-            ctx.fillStyle = color.bg;
-            ctx.beginPath();
-            for (var t = 0; t <= r.years; t++) {
-                var xp = pad.left + (t / maxYears) * plotW;
-                var yp = pad.top + (1 - r.balances[t] / maxBalance) * plotH;
-                if (t === 0) ctx.moveTo(xp, yp);
-                else ctx.lineTo(xp, yp);
-            }
-            ctx.lineTo(pad.left + (r.years / maxYears) * plotW, pad.top + plotH);
-            ctx.lineTo(pad.left, pad.top + plotH);
-            ctx.closePath();
-            ctx.fill();
+            // Term label
+            ctx.fillStyle = "#555";
+            ctx.textBaseline = "top";
+            ctx.font = '600 10px -apple-system, system-ui, sans-serif';
+            ctx.fillText("TERM " + (i + 1), cx, pad.top + plotH + 6);
+            ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
+            ctx.fillStyle = "#888";
+            ctx.fillText(t.years + "yr @ " + t.rate + "%", cx, pad.top + plotH + 20);
         });
 
+        // Y-axis label
+        ctx.save();
+        ctx.translate(14, pad.top + plotH / 2);
+        ctx.rotate(-Math.PI / 2);
+        ctx.fillStyle = "#888";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.font = '600 10px -apple-system, system-ui, sans-serif';
+        ctx.fillText("INTEREST PAID", 0, 0);
+        ctx.restore();
+    }
+
+    // --- Pie chart: total cost breakdown ---
+
+    function drawPieChart(sim) {
+        var canvas = document.getElementById("pieChart");
+        var dpr = window.devicePixelRatio || 1;
+        var rect = canvas.getBoundingClientRect();
+        canvas.width = rect.width * dpr;
+        canvas.height = rect.height * dpr;
+        var ctx = canvas.getContext("2d");
+        ctx.scale(dpr, dpr);
+
+        var W = rect.width;
+        var H = rect.height;
+        ctx.clearRect(0, 0, W, H);
+
+        var slices = [
+            { label: "Principal", value: sim.totalPrincipalPaid, color: pieColors[0] },
+            { label: "Interest", value: sim.totalInterest, color: pieColors[1] },
+            { label: "Property Tax", value: sim.totalTax, color: pieColors[2] },
+            { label: "Insurance", value: sim.totalInsurance, color: pieColors[3] },
+            { label: country === "ca" ? "Condo Fees" : "HOA", value: sim.totalHOA, color: pieColors[4] },
+        ];
+
+        if (sim.totalPMI > 0) {
+            slices.push({ label: sim.pmiLabel, value: sim.totalPMI, color: pieColors[5] });
+        }
+
+        slices = slices.filter(function (s) { return s.value > 0; });
+
+        if (slices.length === 0) return;
+
+        var total = 0;
+        slices.forEach(function (s) { total += s.value; });
+        if (total === 0) return;
+
+        var cx = W * 0.35;
+        var cy = H / 2;
+        var radius = Math.min(cx - 20, cy - 15, 100);
+        var startAngle = -Math.PI / 2;
+
+        slices.forEach(function (s) {
+            var sliceAngle = (s.value / total) * 2 * Math.PI;
+            ctx.beginPath();
+            ctx.moveTo(cx, cy);
+            ctx.arc(cx, cy, radius, startAngle, startAngle + sliceAngle);
+            ctx.closePath();
+            ctx.fillStyle = s.color;
+            ctx.fill();
+            startAngle += sliceAngle;
+        });
+
+        // Inner circle for donut
+        ctx.beginPath();
+        ctx.arc(cx, cy, radius * 0.52, 0, Math.PI * 2);
+        ctx.fillStyle = "#fafafa";
+        ctx.fill();
+
+        // Center text
+        ctx.fillStyle = "#111";
+        ctx.font = '600 13px "SF Mono", "Roboto Mono", Menlo, monospace';
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText(fmt(total), cx, cy - 6);
+        ctx.font = '600 9px -apple-system, system-ui, sans-serif';
+        ctx.fillStyle = "#888";
+        ctx.letterSpacing = "0.05em";
+        ctx.fillText("TOTAL COST", cx, cy + 8);
+
         // Legend
-        ctx.font = "12px system-ui, sans-serif";
+        var legendX = W * 0.65;
+        var legendY = cy - slices.length * 13;
         ctx.textAlign = "left";
         ctx.textBaseline = "middle";
-        var legendX = pad.left + 10;
-        var legendY = pad.top + 12;
-        results.forEach(function (r, i) {
-            var color = colors[i % colors.length];
-            ctx.fillStyle = color.line;
-            ctx.fillRect(legendX, legendY - 5, 14, 10);
-            ctx.fillStyle = "#555";
-            ctx.fillText(r.years + " yr", legendX + 20, legendY);
-            legendX += 70;
+        ctx.font = '600 10px -apple-system, system-ui, sans-serif';
+
+        slices.forEach(function (s, i) {
+            var ly = legendY + i * 26;
+            ctx.fillStyle = s.color;
+            ctx.fillRect(legendX, ly - 5, 12, 10);
+
+            ctx.fillStyle = "#111";
+            ctx.fillText(s.label, legendX + 18, ly);
+
+            ctx.fillStyle = "#888";
+            ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
+            ctx.fillText(fmt(s.value) + " (" + (s.value / total * 100).toFixed(1) + "%)", legendX + 18, ly + 13);
+            ctx.font = '600 10px -apple-system, system-ui, sans-serif';
         });
     }
 
-    // Toggle buttons
-    toggleButtons.forEach(function (btn) {
-        btn.addEventListener("click", function () {
-            btn.classList.toggle("active");
-            btn.setAttribute("aria-pressed", btn.classList.contains("active"));
-            render();
-        });
+    // --- Amortization schedule ---
+
+    function renderSchedule(sim) {
+        scheduleSection.style.display = "block";
+        var rows = sim.schedule;
+
+        if (scheduleMode === "annual") {
+            var byYear = {};
+            rows.forEach(function (r) {
+                var key = r.year;
+                if (!byYear[key]) byYear[key] = { year: key, termIndex: r.termIndex, payment: 0, principal: 0, interest: 0, tax: 0, insurance: 0, hoa: 0, pmi: 0, balance: 0 };
+                byYear[key].payment += r.payment;
+                byYear[key].principal += r.principal;
+                byYear[key].interest += r.interest;
+                byYear[key].tax += r.tax;
+                byYear[key].insurance += r.insurance;
+                byYear[key].hoa += r.hoa;
+                byYear[key].pmi += r.pmi;
+                byYear[key].balance = r.balance;
+            });
+            var yearRows = Object.keys(byYear).sort(function (a, b) { return a - b; }).map(function (k) { return byYear[k]; });
+
+            scheduleTableHead.innerHTML = "<tr><th>Year</th><th>Payment</th><th>Principal</th><th>Interest</th>" +
+                (sim.totalPMI > 0 ? "<th>" + sim.pmiLabel + "</th>" : "") +
+                "<th>Tax</th><th>Ins.</th><th>" + (country === "ca" ? "Condo" : "HOA") + "</th><th>Balance</th></tr>";
+
+            var html = "";
+            var prevTerm = -1;
+            yearRows.forEach(function (r) {
+                var cls = r.termIndex !== prevTerm ? ' class="term-boundary"' : "";
+                prevTerm = r.termIndex;
+                html += "<tr" + cls + ">" +
+                    "<td>" + r.year + "</td>" +
+                    "<td>" + fmt(r.payment) + "</td>" +
+                    "<td>" + fmt(r.principal) + "</td>" +
+                    "<td>" + fmt(r.interest) + "</td>" +
+                    (sim.totalPMI > 0 ? "<td>" + fmt(r.pmi) + "</td>" : "") +
+                    "<td>" + fmt(r.tax) + "</td>" +
+                    "<td>" + fmt(r.insurance) + "</td>" +
+                    "<td>" + fmt(r.hoa) + "</td>" +
+                    "<td>" + fmt(r.balance) + "</td>" +
+                    "</tr>";
+            });
+            scheduleTableBody.innerHTML = html;
+        } else {
+            scheduleTableHead.innerHTML = "<tr><th>Date</th><th>Payment</th><th>Principal</th><th>Interest</th>" +
+                (sim.totalPMI > 0 ? "<th>" + sim.pmiLabel + "</th>" : "") +
+                "<th>Balance</th></tr>";
+
+            var html = "";
+            var prevTerm = -1;
+            rows.forEach(function (r) {
+                var cls = r.termIndex !== prevTerm ? ' class="term-boundary"' : "";
+                prevTerm = r.termIndex;
+                html += "<tr" + cls + ">" +
+                    "<td>" + monthNames[r.month] + " " + r.year + "</td>" +
+                    "<td>" + fmt(r.payment) + "</td>" +
+                    "<td>" + fmt(r.principal) + "</td>" +
+                    "<td>" + fmt(r.interest) + "</td>" +
+                    (sim.totalPMI > 0 ? "<td>" + fmt(r.pmi) + "</td>" : "") +
+                    "<td>" + fmt(r.balance) + "</td>" +
+                    "</tr>";
+            });
+            scheduleTableBody.innerHTML = html;
+        }
+    }
+
+    // Schedule toggle
+    btnMonthly.addEventListener("click", function () {
+        scheduleMode = "monthly";
+        btnMonthly.classList.add("active");
+        btnAnnual.classList.remove("active");
+        if (lastSimResult) renderSchedule(lastSimResult);
     });
 
-    // Input listeners
-    principalInput.addEventListener("input", render);
-    rateInput.addEventListener("input", render);
+    btnAnnual.addEventListener("click", function () {
+        scheduleMode = "annual";
+        btnAnnual.classList.add("active");
+        btnMonthly.classList.remove("active");
+        if (lastSimResult) renderSchedule(lastSimResult);
+    });
 
-    // Redraw chart on resize
+    // --- Event bindings ---
+
+    [amortInput, paymentIncreaseInput, lumpSumAnnualInput, lumpSumTermInput,
+     propertyTaxInput, homeInsuranceInput, hoaInput, pmiInput, startYearInput].forEach(function (el) {
+        el.addEventListener("input", render);
+    });
+
+    startMonthInput.addEventListener("change", render);
+
     var resizeTimer;
     window.addEventListener("resize", function () {
         clearTimeout(resizeTimer);
-        resizeTimer = setTimeout(render, 150);
+        resizeTimer = setTimeout(function () { if (lastSimResult) render(); }, 150);
     });
 
-    // Initial render
+    // --- Init ---
+
+    var saved = loadState();
+    if (saved && applyState(saved)) {
+        // Restored from localStorage
+    } else {
+        terms = countryConfig.ca.defaultTerms.map(function (t) { return { years: t.years, rate: t.rate, schedule: t.schedule }; });
+    }
+    syncLoan();
+    renderTerms();
+    renderCountryInfo();
+    loadCollapsedState();
     render();
+
+    // Clear all button
+    btnClear.addEventListener("click", function () {
+        clearState();
+        try { localStorage.removeItem(LS_KEY + "-collapsed"); } catch (e) {}
+        country = "ca";
+        btnCA.classList.add("active");
+        btnUS.classList.remove("active");
+        var cfg = countryConfig.ca;
+        pmiLabel.textContent = cfg.insuranceLabel;
+        hoaLabel.textContent = cfg.hoaLabel;
+        propertyTaxLabel.textContent = cfg.taxLabel;
+        amortInput.max = cfg.maxAmort;
+
+        homeValueInput.value = 500000;
+        downPaymentInput.value = 100000;
+        amortInput.value = cfg.defaultAmort;
+        paymentIncreaseInput.value = 0;
+        lumpSumAnnualInput.value = 0;
+        lumpSumTermInput.value = 0;
+        propertyTaxInput.value = 3500;
+        homeInsuranceInput.value = 1200;
+        hoaInput.value = 0;
+        pmiInput.value = 0;
+        startMonthInput.value = 5;
+        startYearInput.value = 2026;
+
+        terms = cfg.defaultTerms.map(function (t) { return { years: t.years, rate: t.rate, schedule: t.schedule }; });
+
+        // Reset collapsibles to collapsed
+        Object.keys(collapsibles).forEach(function (key) {
+            collapsibles[key].body.classList.add("collapsed");
+            collapsibles[key].arrow.classList.remove("open");
+        });
+
+        renderTerms();
+        syncLoan();
+        renderCountryInfo();
+        render();
+    });
 })();

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -100,8 +100,20 @@
         },
     };
 
-    var termColors = ["#111", "#4a4a4a", "#7a7a7a", "#a5a5a5", "#c5c5c5", "#333", "#5a5a5a", "#8a8a8a"];
-    var pieColors = ["#111", "#4a4a4a", "#7a7a7a", "#a5a5a5", "#c5c5c5", "#ddd"];
+    var termColorsLight = ["#111", "#4a4a4a", "#7a7a7a", "#a5a5a5", "#c5c5c5", "#333", "#5a5a5a", "#8a8a8a"];
+    var termColorsDark = ["#e0e0e0", "#b0b0b0", "#888888", "#666666", "#444444", "#ccc", "#999", "#777"];
+    var pieColorsLight = ["#111", "#4a4a4a", "#7a7a7a", "#a5a5a5", "#c5c5c5", "#ddd"];
+    var pieColorsDark = ["#e0e0e0", "#b0b0b0", "#888888", "#666666", "#444444", "#333"];
+
+    function termColors() {
+        var dark = getComputedStyle(document.documentElement).getPropertyValue('--bg').trim() !== '#fafafa';
+        return dark ? termColorsDark : termColorsLight;
+    }
+
+    function pieColors() {
+        var dark = getComputedStyle(document.documentElement).getPropertyValue('--bg').trim() !== '#fafafa';
+        return dark ? pieColorsDark : pieColorsLight;
+    }
     var monthNames = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
 
     // --- Country presets ---
@@ -475,7 +487,6 @@
         var totalPMI = 0;
         var termResults = [];
         var schedule = [];
-        var currentYear = 0;
         var globalMonth = 0;
         var compounding = countryConfig[country].compounding;
         var pmiIsOngoing = country === "us"; // US: ongoing PMI, CA: upfront CMHC (already in loan)
@@ -490,7 +501,6 @@
 
             var basePayment = calcBasePayment(balance, term.rate, remainingAmort, term.schedule, compounding);
             var payment = basePayment;
-            var yearInMortgage = currentYear;
             var paymentsThisYear = 0;
             var termPrincipal = 0;
             var termInterest = 0;
@@ -503,7 +513,6 @@
                 // Annual payment increase
                 if (p > 0 && p % ppy === 0) {
                     payment += annualIncrease;
-                    yearInMortgage++;
                     paymentsThisYear = 0;
                 }
 
@@ -597,7 +606,6 @@
                 pmiLabel: insuranceLabel,
             });
 
-            currentYear += term.years;
         }
 
         return {
@@ -696,11 +704,11 @@
                 '<div class="scenario-compare">' +
                 '<table class="scenario-table">' +
                 '<thead><tr><th></th>' +
-                '<th><span class="scenario-label opt">Optimistic ' + fmtPct(optOffset) + '</span></th>' +
+                '<th><span class="scenario-label opt">Optimistic (' + fmtPct(optOffset) + ')</span></th>' +
                 '<th>Base</th>' +
-                '<th><span class="scenario-label pess">Pessimistic +' + fmtPct(pessOffset) + '</span></th>' +
+                '<th><span class="scenario-label pess">Pessimistic (+' + fmtPct(pessOffset) + ')</span></th>' +
                 '</tr></thead><tbody>' +
-                '<tr><td>Monthly Payment</td><td>' + fmtFull(simOpt.termResults[0].basePayment) + '</td><td>' + fmtFull(sim.termResults[0].basePayment) + '</td><td>' + fmtFull(simPess.termResults[0].basePayment) + '</td></tr>' +
+                '<tr><td>' + scheduleLabel(terms[0].schedule).charAt(0).toUpperCase() + scheduleLabel(terms[0].schedule).slice(1) + ' Payment</td><td>' + fmtFull(simOpt.termResults[0].basePayment) + '</td><td>' + fmtFull(sim.termResults[0].basePayment) + '</td><td>' + fmtFull(simPess.termResults[0].basePayment) + '</td></tr>' +
                 '<tr><td>Total Interest</td><td>' + fmt(simOpt.totalInterest) + '</td><td>' + fmt(sim.totalInterest) + '</td><td>' + fmt(simPess.totalInterest) + '</td></tr>' +
                 '<tr><td>Total Cost</td><td>' + fmt(simOpt.totalAllIn) + '</td><td>' + fmt(sim.totalAllIn) + '</td><td>' + fmt(simPess.totalAllIn) + '</td></tr>' +
                 '<tr><td>Interest Share</td><td>' + fmtPct(simOpt.totalPaid > 0 ? simOpt.totalInterest / simOpt.totalPaid * 100 : 0) + '</td><td>' + fmtPct(sim.totalPaid > 0 ? sim.totalInterest / sim.totalPaid * 100 : 0) + '</td><td>' + fmtPct(simPess.totalPaid > 0 ? simPess.totalInterest / simPess.totalPaid * 100 : 0) + '</td></tr>' +
@@ -722,7 +730,7 @@
         }
 
         if (!sim.paidOff) {
-            html += '<p class="hint" style="margin-top:0.5rem;color:#c0392b;font-size:0.8125rem;font-weight:600;">Mortgage not fully paid after all terms. Remaining balance: ' + fmt(sim.termResults[sim.termResults.length - 1].balanceAtEnd) + '</p>';
+            html += '<p class="hint warning">Mortgage not fully paid after all terms. Remaining balance: ' + fmt(sim.termResults[sim.termResults.length - 1].balanceAtEnd) + '</p>';
         }
 
         resultsEl.innerHTML = html;
@@ -798,7 +806,7 @@
             var x = cx - barWidth / 2;
             var bHeight = (t.interestPaid / niceMax) * plotH;
 
-            ctx.fillStyle = termColors[i % termColors.length];
+            ctx.fillStyle = termColors()[i % termColors().length];
             ctx.fillRect(x, pad.top + plotH - bHeight, barWidth, bHeight);
 
             // Value on top
@@ -845,16 +853,17 @@
         var H = rect.height;
         ctx.clearRect(0, 0, W, H);
 
+        var pc = pieColors();
         var slices = [
-            { label: "Principal", value: sim.totalPrincipalPaid, color: pieColors[0] },
-            { label: "Interest", value: sim.totalInterest, color: pieColors[1] },
-            { label: "Property Tax", value: sim.totalTax, color: pieColors[2] },
-            { label: "Insurance", value: sim.totalInsurance, color: pieColors[3] },
-            { label: country === "ca" ? "Condo Fees" : "HOA", value: sim.totalHOA, color: pieColors[4] },
+            { label: "Principal", value: sim.totalPrincipalPaid, color: pc[0] },
+            { label: "Interest", value: sim.totalInterest, color: pc[1] },
+            { label: "Property Tax", value: sim.totalTax, color: pc[2] },
+            { label: "Insurance", value: sim.totalInsurance, color: pc[3] },
+            { label: country === "ca" ? "Condo Fees" : "HOA", value: sim.totalHOA, color: pc[4] },
         ];
 
         if (sim.totalPMI > 0) {
-            slices.push({ label: sim.pmiLabel, value: sim.totalPMI, color: pieColors[5] });
+            slices.push({ label: sim.pmiLabel, value: sim.totalPMI, color: pc[5] });
         }
 
         slices = slices.filter(function (s) { return s.value > 0; });

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -218,13 +218,6 @@
         return val.toFixed(1) + "%";
     }
 
-    function fmtShort(val) {
-        if (Math.abs(val) >= 1000000) {
-            return "$" + (val / 1000000).toFixed(1) + "M";
-        }
-        return fmt(val);
-    }
-
     // --- Local storage ---
 
     function saveState() {

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -1,727 +1,102 @@
 (function () {
-    // --- DOM refs ---
-    var homeValueInput = document.getElementById("home-value");
-    var downPaymentInput = document.getElementById("down-payment");
-    var loanAmountInput = document.getElementById("loan-amount");
-    var downPctEl = document.getElementById("down-pct");
-    var amortInput = document.getElementById("amortization");
-    var paymentIncreaseInput = document.getElementById("payment-increase");
-    var lumpSumAnnualInput = document.getElementById("lump-sum-annual");
-    var lumpSumTermInput = document.getElementById("lump-sum-term");
-    var propertyTaxInput = document.getElementById("property-tax");
-    var homeInsuranceInput = document.getElementById("home-insurance");
-    var hoaInput = document.getElementById("hoa");
-    var pmiInput = document.getElementById("pmi");
-    var pmiRow = document.getElementById("pmi-row");
-    var pmiHint = document.getElementById("pmi-hint");
-    var pmiLabel = document.getElementById("pmi-label");
-    var hoaLabel = document.getElementById("hoa-label");
-    var propertyTaxLabel = document.getElementById("property-tax-label");
-    var startMonthInput = document.getElementById("start-month");
-    var startYearInput = document.getElementById("start-year");
-    var termsList = document.getElementById("terms-list");
-    var addTermBtn = document.getElementById("add-term");
+    var principalInput = document.getElementById("principal");
+    var rateInput = document.getElementById("rate");
     var resultsEl = document.getElementById("results");
     var chartSection = document.getElementById("chart-section");
-    var pieSection = document.getElementById("pie-section");
-    var scheduleSection = document.getElementById("schedule-section");
-    var scheduleTableBody = document.querySelector("#schedule-table tbody");
-    var scheduleTableHead = document.querySelector("#schedule-table thead");
-    var btnMonthly = document.getElementById("btn-monthly");
-    var btnAnnual = document.getElementById("btn-annual");
-    var btnCA = document.getElementById("btn-ca");
-    var btnUS = document.getElementById("btn-us");
-    var countryInfoEl = document.getElementById("country-info");
-    var btnClear = document.getElementById("btn-clear");
-    var hookLoan = document.getElementById("hook-loan");
-    var hookInterest = document.getElementById("hook-interest");
+    var toggleButtons = document.querySelectorAll(".term-toggle");
 
-    // Collapsible sections
-    var collapsibles = {
-        prepay: { toggle: document.getElementById("toggle-prepay"), body: document.getElementById("body-prepay"), arrow: document.getElementById("arrow-prepay") },
-        costs:  { toggle: document.getElementById("toggle-costs"),  body: document.getElementById("body-costs"),  arrow: document.getElementById("arrow-arrow-costs") },
-        date:   { toggle: document.getElementById("toggle-date"),   body: document.getElementById("body-date"),   arrow: document.getElementById("arrow-date") },
-    };
-    // Fix arrow-costs id
-    collapsibles.costs.arrow = document.getElementById("arrow-costs");
+    var colors = [
+        { line: "#e74c3c", bg: "rgba(231,76,60,0.10)" },
+        { line: "#3498db", bg: "rgba(52,152,219,0.10)" },
+        { line: "#2ecc71", bg: "rgba(46,204,113,0.10)" },
+        { line: "#f39c12", bg: "rgba(243,156,18,0.10)" },
+        { line: "#9b59b6", bg: "rgba(155,89,182,0.10)" },
+    ];
 
-    // Collapsible toggle handlers
-    Object.keys(collapsibles).forEach(function (key) {
-        var c = collapsibles[key];
-        c.toggle.addEventListener("click", function () {
-            var isOpen = !c.body.classList.contains("collapsed");
-            c.body.classList.toggle("collapsed", isOpen);
-            c.arrow.classList.toggle("open", !isOpen);
-            saveCollapsedState();
-        });
-    });
-
-    function saveCollapsedState() {
-        try {
-            var state = {};
-            Object.keys(collapsibles).forEach(function (key) {
-                state[key] = collapsibles[key].body.classList.contains("collapsed");
-            });
-            localStorage.setItem(LS_KEY + "-collapsed", JSON.stringify(state));
-        } catch (e) {}
-    }
-
-    function loadCollapsedState() {
-        try {
-            var raw = localStorage.getItem(LS_KEY + "-collapsed");
-            if (!raw) return;
-            var state = JSON.parse(raw);
-            Object.keys(state).forEach(function (key) {
-                if (collapsibles[key]) {
-                    collapsibles[key].body.classList.toggle("collapsed", state[key]);
-                    collapsibles[key].arrow.classList.toggle("open", !state[key]);
-                }
-            });
-        } catch (e) {}
-    }
-
-    var countryInfo = {
-        ca: {
-            bullets: [
-                "<strong>Semi-annual compounding.</strong> Interest compounds twice a year, so the effective monthly rate is lower than rate/12.",
-                "<strong>CMHC default insurance</strong> required when down payment is under 20%. Premium is a one-time cost (0.6% to 4% of loan) added to the mortgage.",
-                "<strong>Term vs amortization.</strong> Typical terms are 1-5 years at a fixed rate; the amortization is 25-30 years. Rate renegotiated at each renewal.",
-                "<strong>Prepayment limits.</strong> Most lenders allow 10-20% lump sum per year and payment increases up to double. Penalties apply beyond that.",
-            ],
-        },
-        us: {
-            bullets: [
-                "<strong>Monthly compounding.</strong> Interest is calculated at rate/12 each month. The quoted rate equals the effective rate.",
-                "<strong>PMI</strong> required when down payment is under 20%. Ongoing monthly cost that cancels automatically at 78-80% LTV.",
-                "<strong>30-year fixed</strong> is the most common mortgage. You lock the rate for the entire loan. No renewals.",
-                "<strong>HOA</strong> (Homeowners Association) fees are common for condos and planned communities. Typically paid monthly.",
-            ],
-        },
-    };
-
-    var termColors = ["#111", "#4a4a4a", "#7a7a7a", "#a5a5a5", "#c5c5c5", "#333", "#5a5a5a", "#8a8a8a"];
-    var pieColors = ["#111", "#4a4a4a", "#7a7a7a", "#a5a5a5", "#c5c5c5", "#ddd"];
-    var monthNames = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
-
-    // --- Country presets ---
-    var countryConfig = {
-        ca: {
-            defaultAmort: 25,
-            maxAmort: 30,
-            defaultTerms: [
-                { years: 5, rate: 4.99, schedule: "monthly" },
-                { years: 5, rate: 4.49, schedule: "monthly" },
-                { years: 5, rate: 4.19, schedule: "monthly" },
-                { years: 5, rate: 3.99, schedule: "monthly" },
-                { years: 5, rate: 3.79, schedule: "monthly" },
-            ],
-            compounding: "semi-annual", // Canadian fixed mortgages compound semi-annually
-            insuranceLabel: "Default Insurance (CMHC)",
-            hoaLabel: "Condo Fees / Month",
-            taxLabel: "Property Tax / Year",
-            newTermDuration: 5,
-            pmiEstimate: function (downPct) {
-                // CMHC rates: 4% for 5-9.99%, 3.1% for 10-14.99%, 2.4% for 15-19.99%
-                if (downPct < 5) return 4.0;
-                if (downPct < 10) return 3.1;
-                if (downPct < 15) return 2.4;
-                if (downPct < 20) return 1.8;
-                return 0;
-            },
-            pmiIsUpfront: true, // CMHC is a one-time premium added to loan
-        },
-        us: {
-            defaultAmort: 30,
-            maxAmort: 40,
-            defaultTerms: [
-                { years: 30, rate: 6.5, schedule: "monthly" },
-            ],
-            compounding: "monthly",
-            insuranceLabel: "PMI",
-            hoaLabel: "HOA / Month",
-            taxLabel: "Property Tax / Year",
-            newTermDuration: 5,
-            pmiEstimate: function (downPct) {
-                if (downPct < 5) return 1.5;
-                if (downPct < 10) return 1.0;
-                if (downPct < 15) return 0.6;
-                if (downPct < 20) return 0.3;
-                return 0;
-            },
-            pmiIsUpfront: false, // PMI is ongoing monthly
-        },
-    };
-
-    var country = "ca";
-    var terms = [];
-    var scheduleMode = "annual";
-    var lastSimResult = null;
-    var LS_KEY = "mortgage-calc-v1";
-
-    // --- Helpers ---
-
-    function schedulePaymentsPerYear(schedule) {
-        if (schedule === "biweekly") return 26;
-        if (schedule === "weekly") return 52;
-        return 12;
-    }
-
-    function scheduleLabel(schedule) {
-        if (schedule === "biweekly") return "bi-weekly";
-        if (schedule === "weekly") return "weekly";
-        return "monthly";
-    }
-
-    // Canadian mortgage: effective monthly rate from semi-annual compounding
-    // rate_semi = annualRate/2, effective monthly = (1 + rate_semi)^^(2/12) - 1
-    function effectiveMonthlyRate(annualRate, compounding) {
-        if (compounding === "semi-annual") {
-            var semiRate = annualRate / 100 / 2;
-            return Math.pow(1 + semiRate, 1 / 6) - 1;
-        }
-        // US: monthly compounding
-        return annualRate / 100 / 12;
-    }
-
-    function calcBasePayment(principal, annualRate, amortYears, schedule, compounding) {
-        var ppy = schedulePaymentsPerYear(schedule);
-        var n = amortYears * ppy;
-        if (principal <= 0 || n <= 0) return 0;
-
-        var r;
-        if (compounding === "semi-annual") {
-            // For Canadian mortgages, convert to effective period rate
-            var monthlyRate = effectiveMonthlyRate(annualRate, "semi-annual");
-            if (schedule === "monthly") {
-                r = monthlyRate;
-            } else if (schedule === "biweekly") {
-                r = Math.pow(1 + monthlyRate, 1 / 2) - 1;
-            } else {
-                r = Math.pow(1 + monthlyRate, 1 / 4) - 1;
+    function getActiveTerms() {
+        var terms = [];
+        toggleButtons.forEach(function (btn) {
+            if (btn.classList.contains("active")) {
+                terms.push(parseInt(btn.dataset.term, 10));
             }
-        } else {
-            r = annualRate / 100 / ppy;
-        }
+        });
+        return terms.sort(function (a, b) { return a - b; });
+    }
 
-        if (r === 0) return principal / n;
+    function calcMonthly(principal, annualRate, years) {
+        if (principal <= 0 || years <= 0) return 0;
+        if (annualRate === 0) return principal / (years * 12);
+        var r = annualRate / 100 / 12;
+        var n = years * 12;
         return principal * (r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1);
     }
 
-    function addCommas(n) {
-        var parts = n.toString().split(".");
-        parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-        return parts.join(".");
-    }
+    function calcAmortization(principal, annualRate, years) {
+        var monthly = calcMonthly(principal, annualRate, years);
+        var r = annualRate / 100 / 12;
+        var n = years * 12;
+        var totalPaid = monthly * n;
+        var totalInterest = totalPaid - principal;
 
-    function fmt(val) {
-        return "$" + addCommas(Math.round(val));
-    }
-
-    function fmtFull(val) {
-        var rounded = Math.round(val * 100) / 100;
-        var parts = rounded.toFixed(2).split(".");
-        return "$" + addCommas(parseInt(parts[0])) + "." + parts[1];
-    }
-
-    function fmtPct(val) {
-        return val.toFixed(1) + "%";
-    }
-
-    function fmtShort(val) {
-        if (Math.abs(val) >= 1000000) {
-            return "$" + (val / 1000000).toFixed(1) + "M";
-        }
-        return fmt(val);
-    }
-
-    // --- Local storage ---
-
-    function saveState() {
-        try {
-            var state = {
-                country: country,
-                homeValue: homeValueInput.value,
-                downPayment: downPaymentInput.value,
-                amortization: amortInput.value,
-                paymentIncrease: paymentIncreaseInput.value,
-                lumpSumAnnual: lumpSumAnnualInput.value,
-                lumpSumTerm: lumpSumTermInput.value,
-                propertyTax: propertyTaxInput.value,
-                homeInsurance: homeInsuranceInput.value,
-                hoa: hoaInput.value,
-                pmi: pmiInput.value,
-                startMonth: startMonthInput.value,
-                startYear: startYearInput.value,
-                terms: terms,
-            };
-            localStorage.setItem(LS_KEY, JSON.stringify(state));
-        } catch (e) { /* storage full or unavailable */ }
-    }
-
-    function loadState() {
-        try {
-            var raw = localStorage.getItem(LS_KEY);
-            if (!raw) return null;
-            return JSON.parse(raw);
-        } catch (e) { return null; }
-    }
-
-    function clearState() {
-        try { localStorage.removeItem(LS_KEY); } catch (e) {}
-    }
-
-    function applyState(s) {
-        if (!s) return false;
-        if (s.country && countryConfig[s.country]) {
-            country = s.country;
-            btnCA.classList.toggle("active", country === "ca");
-            btnUS.classList.toggle("active", country === "us");
-            var cfg = countryConfig[country];
-            pmiLabel.textContent = cfg.insuranceLabel;
-            hoaLabel.textContent = cfg.hoaLabel;
-            propertyTaxLabel.textContent = cfg.taxLabel;
-            amortInput.max = cfg.maxAmort;
-        }
-        if (s.homeValue !== undefined) homeValueInput.value = s.homeValue;
-        if (s.downPayment !== undefined) downPaymentInput.value = s.downPayment;
-        if (s.amortization !== undefined) amortInput.value = s.amortization;
-        if (s.paymentIncrease !== undefined) paymentIncreaseInput.value = s.paymentIncrease;
-        if (s.lumpSumAnnual !== undefined) lumpSumAnnualInput.value = s.lumpSumAnnual;
-        if (s.lumpSumTerm !== undefined) lumpSumTermInput.value = s.lumpSumTerm;
-        if (s.propertyTax !== undefined) propertyTaxInput.value = s.propertyTax;
-        if (s.homeInsurance !== undefined) homeInsuranceInput.value = s.homeInsurance;
-        if (s.hoa !== undefined) hoaInput.value = s.hoa;
-        if (s.pmi !== undefined) pmiInput.value = s.pmi;
-        if (s.startMonth !== undefined) startMonthInput.value = s.startMonth;
-        if (s.startYear !== undefined) startYearInput.value = s.startYear;
-        if (s.terms && Array.isArray(s.terms) && s.terms.length > 0) {
-            terms = s.terms;
-        }
-        renderCountryInfo();
-        return true;
-    }
-
-    function renderCountryInfo() {
-        var info = countryInfo[country];
-        if (!info) { countryInfoEl.innerHTML = ""; return; }
-        var html = "<ul>";
-        info.bullets.forEach(function (b) { html += "<li>" + b + "</li>"; });
-        html += "</ul>";
-        countryInfoEl.innerHTML = html;
-    }
-
-    // --- Country switching ---
-
-    function switchCountry(c) {
-        country = c;
-        btnCA.classList.toggle("active", c === "ca");
-        btnUS.classList.toggle("active", c === "us");
-
-        var cfg = countryConfig[country];
-
-        // Update labels
-        pmiLabel.textContent = cfg.insuranceLabel;
-        hoaLabel.textContent = cfg.hoaLabel;
-        propertyTaxLabel.textContent = cfg.taxLabel;
-
-        // Update amortization
-        amortInput.max = cfg.maxAmort;
-        amortInput.value = cfg.defaultAmort;
-
-        // Reset terms to country defaults
-        terms = cfg.defaultTerms.map(function (t) { return { years: t.years, rate: t.rate, schedule: t.schedule }; });
-
-        // Reset PMI — syncLoan will re-estimate based on new country
-        pmiInput.value = 0;
-
-        // Set country-specific defaults for recurring costs
-        if (c === "ca") {
-            propertyTaxInput.value = 3500;
-            homeInsuranceInput.value = 1200;
-            hoaInput.value = 0;
-        } else {
-            propertyTaxInput.value = 5500;
-            homeInsuranceInput.value = 2000;
-            hoaInput.value = 0;
-        }
-
-        renderTerms();
-        syncLoan();
-        render();
-        renderCountryInfo();
-
-        // Auto-expand recurring costs if insurance is relevant
-        var downPct = (parseFloat(homeValueInput.value) || 0) > 0
-            ? (parseFloat(downPaymentInput.value) || 0) / (parseFloat(homeValueInput.value) || 0) * 100
-            : 100;
-        if (downPct < 20) {
-            collapsibles.costs.body.classList.remove("collapsed");
-            collapsibles.costs.arrow.classList.add("open");
-        }
-
-        saveState();
-    }
-
-    btnCA.addEventListener("click", function () { switchCountry("ca"); });
-    btnUS.addEventListener("click", function () { switchCountry("us"); });
-
-    // --- Down payment / loan amount sync ---
-
-    function syncLoan() {
-        var hv = parseFloat(homeValueInput.value) || 0;
-        var dp = parseFloat(downPaymentInput.value) || 0;
-        if (dp > hv) {
-            dp = hv;
-            downPaymentInput.value = dp;
-        }
-        var loan = hv - dp;
-        var cfg = countryConfig[country];
-
-        // Canada: CMHC premium added to loan if down payment < 20%
-        var cmhcPremium = 0;
-        if (country === "ca" && loan > 0) {
-            var downPct = hv > 0 ? dp / hv * 100 : 0;
-            if (downPct < 20) {
-                var cmhcRate = cfg.pmiEstimate(downPct);
-                cmhcPremium = loan * cmhcRate / 100;
-                // CMHC premium can be added to the mortgage
-                loan += cmhcPremium;
-            }
-        }
-
-        loanAmountInput.value = Math.round(loan);
-        var pct = hv > 0 ? (dp / hv * 100) : 0;
-        downPctEl.textContent = pct.toFixed(0) + "%";
-
-        // Insurance visibility
-        if (pct < 20 && (hv - dp) > 0) {
-            pmiRow.style.display = "block";
-            if (country === "ca") {
-                if (parseFloat(pmiInput.value) === 0) {
-                    pmiInput.value = cfg.pmiEstimate(pct);
-                }
-                pmiHint.textContent = "CMHC premium of " + fmt(cmhcPremium) + " added to loan. Down payment under 20% requires default insurance.";
-            } else {
-                if (parseFloat(pmiInput.value) === 0) {
-                    pmiInput.value = cfg.pmiEstimate(pct);
-                }
-                pmiHint.textContent = "Down payment under 20%: PMI typically required until 78-80% LTV. Adjust rate as needed.";
-            }
-        } else {
-            pmiRow.style.display = "none";
-            pmiHint.textContent = "";
-        }
-    }
-
-    homeValueInput.addEventListener("input", syncLoan);
-    downPaymentInput.addEventListener("input", syncLoan);
-
-    // --- Term UI ---
-
-    function renderTerms() {
-        termsList.innerHTML = "";
-        terms.forEach(function (term, i) {
-            var maxDuration = country === "ca" ? 10 : 40;
-            var card = document.createElement("div");
-            card.className = "term-card";
-            card.innerHTML =
-                '<div class="term-card-header">' +
-                '<h3>Term ' + (i + 1) + '</h3>' +
-                (terms.length > 1 ? '<button class="remove-term" data-idx="' + i + '" title="Remove term">&times;</button>' : '') +
-                '</div>' +
-                '<div class="term-fields">' +
-                '<div class="field"><label>Duration</label><div class="input-wrap"><input type="number" data-idx="' + i + '" data-field="years" value="' + term.years + '" min="1" max="' + maxDuration + '" step="1"><span class="suffix">yr</span></div></div>' +
-                '<div class="field"><label>Rate</label><div class="input-wrap"><input type="number" data-idx="' + i + '" data-field="rate" value="' + term.rate + '" min="0" max="30" step="0.01"><span class="suffix">%</span></div></div>' +
-                '<div class="field"><label>Schedule</label><select data-idx="' + i + '" data-field="schedule"><option value="monthly"' + (term.schedule === "monthly" ? " selected" : "") + '>Monthly</option><option value="biweekly"' + (term.schedule === "biweekly" ? " selected" : "") + '>Bi-weekly</option><option value="weekly"' + (term.schedule === "weekly" ? " selected" : "") + '>Weekly</option></select></div>' +
-                '</div>';
-            termsList.appendChild(card);
-        });
-
-        termsList.querySelectorAll("input, select").forEach(function (el) {
-            el.addEventListener("input", function () {
-                var idx = parseInt(el.dataset.idx, 10);
-                var field = el.dataset.field;
-                if (field === "schedule") {
-                    terms[idx][field] = el.value;
-                } else {
-                    terms[idx][field] = parseFloat(el.value) || 0;
-                }
-                render();
-            });
-        });
-
-        termsList.querySelectorAll(".remove-term").forEach(function (btn) {
-            btn.addEventListener("click", function () {
-                terms.splice(parseInt(btn.dataset.idx, 10), 1);
-                renderTerms();
-                render();
-            });
-        });
-    }
-
-    addTermBtn.addEventListener("click", function () {
-        var cfg = countryConfig[country];
-        var lastRate = terms.length > 0 ? terms[terms.length - 1].rate : 5;
-        terms.push({ years: cfg.newTermDuration, rate: Math.max(0.5, lastRate - 0.2), schedule: "monthly" });
-        renderTerms();
-        render();
-    });
-
-    // --- Simulation ---
-
-    function simulateMortgage(principal, amortYears, termDefs, annualIncrease, lumpAnnual, lumpTerm, annualTax, annualInsurance, monthlyHOA, annualPMI, startMonth, startYear) {
+        // Yearly balances for chart
+        var balances = [principal];
         var balance = principal;
-        var remainingAmort = amortYears;
-        var totalInterest = 0;
-        var totalPrincipalPaid = 0;
-        var totalTax = 0;
-        var totalInsurance = 0;
-        var totalHOA = 0;
-        var totalPMI = 0;
-        var termResults = [];
-        var schedule = [];
-        var currentYear = 0;
-        var globalMonth = 0;
-        var compounding = countryConfig[country].compounding;
-        var pmiIsOngoing = country === "us"; // US: ongoing PMI, CA: upfront CMHC (already in loan)
-
-        for (var ti = 0; ti < termDefs.length && balance > 0.01; ti++) {
-            var term = termDefs[ti];
-            var ppy = schedulePaymentsPerYear(term.schedule);
-
-            // Effective period rate
-            var r;
-            if (compounding === "semi-annual") {
-                var monthlyRate = effectiveMonthlyRate(term.rate, "semi-annual");
-                if (term.schedule === "monthly") {
-                    r = monthlyRate;
-                } else if (term.schedule === "biweekly") {
-                    r = Math.pow(1 + monthlyRate, 1 / 2) - 1;
-                } else {
-                    r = Math.pow(1 + monthlyRate, 1 / 4) - 1;
-                }
-            } else {
-                r = term.rate / 100 / ppy;
+        for (var y = 1; y <= years; y++) {
+            for (var m = 0; m < 12; m++) {
+                var interest = balance * r;
+                balance = balance - (monthly - interest);
+                if (balance < 0) balance = 0;
             }
-
-            var termPayments = term.years * ppy;
-
-            var basePayment = calcBasePayment(balance, term.rate, remainingAmort, term.schedule, compounding);
-            var payment = basePayment;
-            var yearInMortgage = currentYear;
-            var paymentsThisYear = 0;
-            var termPrincipal = 0;
-            var termInterest = 0;
-            var termTax = 0;
-            var termInsurance = 0;
-            var termHOA = 0;
-            var termPMI = 0;
-
-            for (var p = 0; p < termPayments && balance > 0.01; p++) {
-                // Annual payment increase
-                if (p > 0 && p % ppy === 0) {
-                    payment += annualIncrease;
-                    yearInMortgage++;
-                    paymentsThisYear = 0;
-                }
-
-                var interestPortion = balance * r;
-                var principalPortion = payment - interestPortion;
-                if (principalPortion > balance) {
-                    principalPortion = balance;
-                }
-
-                // PMI (US only: ongoing until 78-80% LTV)
-                var pmiPortion = 0;
-                if (pmiIsOngoing) {
-                    var downPct = principal > 0 ? ((parseFloat(homeValueInput.value) - balance) / parseFloat(homeValueInput.value) * 100) : 100;
-                    if (downPct < 20) {
-                        pmiPortion = (annualPMI / 100 * balance) / ppy;
-                    }
-                }
-
-                balance -= principalPortion;
-                termPrincipal += principalPortion;
-                termInterest += interestPortion;
-                termPMI += pmiPortion;
-
-                paymentsThisYear++;
-
-                // Schedule row
-                var absMonth = (startMonth + globalMonth) % 12;
-                var absYear = startYear + Math.floor((startMonth + globalMonth) / 12);
-                schedule.push({
-                    month: absMonth,
-                    year: absYear,
-                    termIndex: ti,
-                    payment: principalPortion + interestPortion + pmiPortion,
-                    principal: principalPortion,
-                    interest: interestPortion,
-                    pmi: pmiPortion,
-                    tax: annualTax / ppy,
-                    insurance: annualInsurance / ppy,
-                    hoa: monthlyHOA * 12 / ppy,
-                    balance: Math.max(0, balance),
-                });
-
-                globalMonth++;
-
-                // Annual lump sum
-                if (lumpAnnual > 0 && paymentsThisYear === ppy && balance > 0.01) {
-                    var lumpApply = Math.min(lumpAnnual, balance);
-                    balance -= lumpApply;
-                    termPrincipal += lumpApply;
-                }
-            }
-
-            // Lump sum at renewal
-            if (lumpTerm > 0 && balance > 0.01) {
-                var lumpApplyTerm = Math.min(lumpTerm, balance);
-                balance -= lumpApplyTerm;
-                termPrincipal += lumpApplyTerm;
-            }
-
-            var termYears = term.years;
-            termTax = annualTax * termYears;
-            termInsurance = annualInsurance * termYears;
-            termHOA = monthlyHOA * 12 * termYears;
-
-            totalInterest += termInterest;
-            totalPrincipalPaid += termPrincipal;
-            totalTax += termTax;
-            totalInsurance += termInsurance;
-            totalHOA += termHOA;
-            totalPMI += termPMI;
-
-            remainingAmort -= term.years;
-            if (remainingAmort < 1) remainingAmort = 1;
-
-            var insuranceLabel = country === "ca" ? "CMHC" : "PMI";
-
-            termResults.push({
-                index: ti,
-                years: term.years,
-                rate: term.rate,
-                schedule: term.schedule,
-                basePayment: basePayment,
-                principalPaid: termPrincipal,
-                interestPaid: termInterest,
-                balanceAtEnd: balance,
-                totalPayments: termPrincipal + termInterest,
-                tax: termTax,
-                insurance: termInsurance,
-                hoa: termHOA,
-                pmi: termPMI,
-                pmiLabel: insuranceLabel,
-            });
-
-            currentYear += term.years;
+            balances.push(Math.round(balance * 100) / 100);
         }
 
-        return {
-            totalInterest: totalInterest,
-            totalPrincipalPaid: totalPrincipalPaid,
-            totalPaid: totalInterest + totalPrincipalPaid,
-            totalTax: totalTax,
-            totalInsurance: totalInsurance,
-            totalHOA: totalHOA,
-            totalPMI: totalPMI,
-            totalAllIn: totalPrincipalPaid + totalInterest + totalTax + totalInsurance + totalHOA + totalPMI,
-            termResults: termResults,
-            schedule: schedule,
-            paidOff: balance < 0.01,
-            principal: principal,
-            pmiLabel: country === "ca" ? "Default Ins." : "PMI",
-        };
+        return { monthly: monthly, totalPaid: totalPaid, totalInterest: totalInterest, balances: balances, years: years };
     }
 
-    // --- Results rendering ---
+    function formatCurrency(val) {
+        return "$" + val.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+    }
+
+    function formatCurrencyFull(val) {
+        return "$" + val.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    }
 
     function render() {
-        var principal = parseFloat(loanAmountInput.value) || 0;
-        var amort = parseInt(amortInput.value, 10) || 25;
-        var annualIncrease = parseFloat(paymentIncreaseInput.value) || 0;
-        var lumpAnnual = parseFloat(lumpSumAnnualInput.value) || 0;
-        var lumpTerm = parseFloat(lumpSumTermInput.value) || 0;
-        var annualTax = parseFloat(propertyTaxInput.value) || 0;
-        var annualInsurance = parseFloat(homeInsuranceInput.value) || 0;
-        var monthlyHOA = parseFloat(hoaInput.value) || 0;
-        var annualPMI = parseFloat(pmiInput.value) || 0;
-        var startMonth = parseInt(startMonthInput.value, 10) || 0;
-        var startYear = parseInt(startYearInput.value, 10) || 2026;
+        var principal = parseFloat(principalInput.value) || 0;
+        var rate = parseFloat(rateInput.value) || 0;
+        var terms = getActiveTerms();
 
-        if (principal <= 0 || terms.length === 0) {
-            resultsEl.classList.remove("visible");
-            chartSection.classList.remove("visible");
-            pieSection.classList.remove("visible");
-            scheduleSection.style.display = "none";
+        if (terms.length === 0) {
+            resultsEl.innerHTML = '<p class="hint">Select at least one term to compare.</p>';
+            chartSection.style.display = "none";
             return;
         }
 
-        var sim = simulateMortgage(principal, amort, terms, annualIncrease, lumpAnnual, lumpTerm, annualTax, annualInsurance, monthlyHOA, annualPMI, startMonth, startYear);
-        lastSimResult = sim;
-
-        // Update hook
-        hookLoan.textContent = fmt(principal);
-        hookInterest.textContent = fmt(sim.totalInterest);
-
-        // Summary
-        var html =
-            '<div class="result-summary">' +
-            '<div class="summary-card"><div class="label">Total Cost (All-In)</div><div class="value">' + fmt(sim.totalAllIn) + '</div></div>' +
-            '<div class="summary-card"><div class="label">Total Interest</div><div class="value">' + fmt(sim.totalInterest) + '</div></div>' +
-            '<div class="summary-card accent"><div class="label">Interest / Payments</div><div class="value">' + fmtPct(sim.totalPaid > 0 ? sim.totalInterest / sim.totalPaid * 100 : 0) + '</div></div>' +
-            '</div>';
-
-        // Bi-weekly comparison
-        var firstTerm = sim.termResults[0];
-        if (firstTerm && firstTerm.schedule === "monthly") {
-            var monthlyPay = firstTerm.basePayment;
-            var biweeklyPay = monthlyPay / 2;
-            var biweeklyAnnual = biweeklyPay * 26;
-            var monthlyAnnual = monthlyPay * 12;
-            var extraPerYear = biweeklyAnnual - monthlyAnnual;
-            html += '<div class="biweekly-compare">Switch to bi-weekly payments of <strong>' + fmtFull(biweeklyPay) + '</strong>? That equals <strong>' + fmt(extraPerYear) + ' extra/year</strong> going to principal, cutting years off your mortgage.</div>';
-        }
-
-        // Per-term breakdown
-        sim.termResults.forEach(function (tr, i) {
-            html +=
-                '<div class="term-result">' +
-                '<h4>Term ' + (i + 1) + ' &mdash; ' + tr.years + ' yr @ ' + tr.rate + '% (' + scheduleLabel(tr.schedule) + ')</h4>' +
-                '<dl class="term-result-grid">' +
-                '<div><dt>Payment</dt><dd>' + fmtFull(tr.basePayment) + '</dd></div>' +
-                '<div><dt>Principal Paid</dt><dd>' + fmt(tr.principalPaid) + '</dd></div>' +
-                '<div><dt>Interest Paid</dt><dd>' + fmt(tr.interestPaid) + '</dd></div>' +
-                '<div><dt>Total P&I</dt><dd>' + fmt(tr.totalPayments) + '</dd></div>' +
-                '<div><dt>Balance at End</dt><dd>' + fmt(tr.balanceAtEnd) + '</dd></div>' +
-                '<div><dt>Interest Share</dt><dd>' + fmtPct(tr.totalPayments > 0 ? tr.interestPaid / tr.totalPayments * 100 : 0) + '</dd></div>' +
-                (tr.pmi > 0 ? '<div><dt>' + tr.pmiLabel + '</dt><dd>' + fmt(tr.pmi) + '</dd></div>' : '') +
-                '</dl>' +
-                '</div>';
+        var results = terms.map(function (t) {
+            return calcAmortization(principal, rate, t);
         });
 
-        if (!sim.paidOff) {
-            html += '<p class="hint" style="margin-top:0.5rem;color:#c0392b;font-size:0.8125rem;font-weight:600;">Mortgage not fully paid after all terms. Remaining balance: ' + fmt(sim.termResults[sim.termResults.length - 1].balanceAtEnd) + '</p>';
-        }
+        // Cards
+        resultsEl.innerHTML = results.map(function (r, i) {
+            var years = r.years;
+            return '<div class="result-card">' +
+                '<h3>' + years + '-Year Fixed</h3>' +
+                '<div class="monthly">' + formatCurrencyFull(r.monthly) + ' <span>/mo</span></div>' +
+                '<dl class="result-details">' +
+                '<div><dt>Total Interest</dt><dd>' + formatCurrency(r.totalInterest) + '</dd></div>' +
+                '<div><dt>Total Paid</dt><dd>' + formatCurrency(r.totalPaid) + '</dd></div>' +
+                '<div><dt>Interest %</dt><dd>' + (r.totalPaid > 0 ? (r.totalInterest / r.totalPaid * 100).toFixed(1) : 0) + '%</dd></div>' +
+                '</dl>' +
+                '</div>';
+        }).join("");
 
-        resultsEl.innerHTML = html;
-        resultsEl.classList.add("visible");
-
-        drawInterestChart(sim);
-        chartSection.classList.add("visible");
-
-        drawPieChart(sim);
-        pieSection.classList.add("visible");
-
-        renderSchedule(sim);
-        saveState();
+        // Chart
+        chartSection.style.display = "block";
+        drawChart(results);
     }
 
-    // --- Interest per term bar chart ---
-
-    function drawInterestChart(sim) {
-        var canvas = document.getElementById("interestChart");
+    function drawChart(results) {
+        var canvas = document.getElementById("balanceChart");
         var dpr = window.devicePixelRatio || 1;
         var rect = canvas.getBoundingClientRect();
         canvas.width = rect.width * dpr;
@@ -731,30 +106,20 @@
 
         var W = rect.width;
         var H = rect.height;
-        var pad = { top: 25, right: 20, bottom: 40, left: 60 };
+        var pad = { top: 20, right: 20, bottom: 35, left: 65 };
         var plotW = W - pad.left - pad.right;
         var plotH = H - pad.top - pad.bottom;
 
         ctx.clearRect(0, 0, W, H);
 
-        var tr = sim.termResults;
-        if (tr.length === 0) return;
+        var maxYears = Math.max.apply(null, results.map(function (r) { return r.years; }));
+        var maxBalance = Math.max.apply(null, results.map(function (r) { return r.balances[0]; })) || 1;
 
-        var maxInterest = 0;
-        tr.forEach(function (t) { if (t.interestPaid > maxInterest) maxInterest = t.interestPaid; });
-        if (maxInterest === 0) return;
-
-        var niceMax = Math.ceil(maxInterest / 5000) * 5000;
-        if (niceMax === 0) niceMax = 5000;
-
-        var barGroupWidth = plotW / tr.length;
-        var barWidth = Math.min(barGroupWidth * 0.55, 60);
-
-        // Grid
-        ctx.strokeStyle = "#e2e2e2";
+        // Grid lines
+        ctx.strokeStyle = "#e0e0e0";
         ctx.lineWidth = 1;
-        ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
-        ctx.fillStyle = "#888";
+        ctx.font = "11px system-ui, sans-serif";
+        ctx.fillStyle = "#999";
         ctx.textAlign = "right";
         ctx.textBaseline = "middle";
 
@@ -764,286 +129,87 @@
             ctx.moveTo(pad.left, y);
             ctx.lineTo(pad.left + plotW, y);
             ctx.stroke();
-            var val = niceMax * (1 - g / 4);
-            ctx.fillText(fmt(val), pad.left - 6, y);
+            var val = maxBalance * (1 - g / 4);
+            ctx.fillText(formatCurrency(val), pad.left - 8, y);
         }
 
-        // Bars
-        tr.forEach(function (t, i) {
-            var cx = pad.left + barGroupWidth * i + barGroupWidth / 2;
-            var x = cx - barWidth / 2;
-            var bHeight = (t.interestPaid / niceMax) * plotH;
-
-            ctx.fillStyle = termColors[i % termColors.length];
-            ctx.fillRect(x, pad.top + plotH - bHeight, barWidth, bHeight);
-
-            // Value on top
-            ctx.fillStyle = "#555";
-            ctx.textAlign = "center";
-            ctx.textBaseline = "bottom";
-            ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
-            ctx.fillText(fmt(t.interestPaid), cx, pad.top + plotH - bHeight - 4);
-
-            // Term label
-            ctx.fillStyle = "#555";
-            ctx.textBaseline = "top";
-            ctx.font = '600 10px -apple-system, system-ui, sans-serif';
-            ctx.fillText("TERM " + (i + 1), cx, pad.top + plotH + 6);
-            ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
-            ctx.fillStyle = "#888";
-            ctx.fillText(t.years + "yr @ " + t.rate + "%", cx, pad.top + plotH + 20);
-        });
-
-        // Y-axis label
-        ctx.save();
-        ctx.translate(14, pad.top + plotH / 2);
-        ctx.rotate(-Math.PI / 2);
-        ctx.fillStyle = "#888";
+        // X axis labels
         ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.font = '600 10px -apple-system, system-ui, sans-serif';
-        ctx.fillText("INTEREST PAID", 0, 0);
-        ctx.restore();
-    }
-
-    // --- Pie chart: total cost breakdown ---
-
-    function drawPieChart(sim) {
-        var canvas = document.getElementById("pieChart");
-        var dpr = window.devicePixelRatio || 1;
-        var rect = canvas.getBoundingClientRect();
-        canvas.width = rect.width * dpr;
-        canvas.height = rect.height * dpr;
-        var ctx = canvas.getContext("2d");
-        ctx.scale(dpr, dpr);
-
-        var W = rect.width;
-        var H = rect.height;
-        ctx.clearRect(0, 0, W, H);
-
-        var slices = [
-            { label: "Principal", value: sim.totalPrincipalPaid, color: pieColors[0] },
-            { label: "Interest", value: sim.totalInterest, color: pieColors[1] },
-            { label: "Property Tax", value: sim.totalTax, color: pieColors[2] },
-            { label: "Insurance", value: sim.totalInsurance, color: pieColors[3] },
-            { label: country === "ca" ? "Condo Fees" : "HOA", value: sim.totalHOA, color: pieColors[4] },
-        ];
-
-        if (sim.totalPMI > 0) {
-            slices.push({ label: sim.pmiLabel, value: sim.totalPMI, color: pieColors[5] });
+        ctx.textBaseline = "top";
+        var xSteps = Math.min(maxYears, 6);
+        for (var x = 0; x <= xSteps; x++) {
+            var year = Math.round(maxYears / xSteps * x);
+            var xp = pad.left + (year / maxYears) * plotW;
+            ctx.fillText(year + "yr", xp, pad.top + plotH + 8);
         }
 
-        slices = slices.filter(function (s) { return s.value > 0; });
-
-        if (slices.length === 0) return;
-
-        var total = 0;
-        slices.forEach(function (s) { total += s.value; });
-        if (total === 0) return;
-
-        var cx = W * 0.35;
-        var cy = H / 2;
-        var radius = Math.min(cx - 20, cy - 15, 100);
-        var startAngle = -Math.PI / 2;
-
-        slices.forEach(function (s) {
-            var sliceAngle = (s.value / total) * 2 * Math.PI;
+        // Lines
+        results.forEach(function (r, i) {
+            var color = colors[i % colors.length];
+            ctx.strokeStyle = color.line;
+            ctx.lineWidth = 2.5;
             ctx.beginPath();
-            ctx.moveTo(cx, cy);
-            ctx.arc(cx, cy, radius, startAngle, startAngle + sliceAngle);
+
+            var step = maxYears / 60; // ~60 data points for longest
+            for (var t = 0; t <= r.years; t++) {
+                var xp = pad.left + (t / maxYears) * plotW;
+                var yp = pad.top + (1 - r.balances[t] / maxBalance) * plotH;
+                if (t === 0) ctx.moveTo(xp, yp);
+                else ctx.lineTo(xp, yp);
+            }
+            ctx.stroke();
+
+            // Light fill
+            ctx.fillStyle = color.bg;
+            ctx.beginPath();
+            for (var t = 0; t <= r.years; t++) {
+                var xp = pad.left + (t / maxYears) * plotW;
+                var yp = pad.top + (1 - r.balances[t] / maxBalance) * plotH;
+                if (t === 0) ctx.moveTo(xp, yp);
+                else ctx.lineTo(xp, yp);
+            }
+            ctx.lineTo(pad.left + (r.years / maxYears) * plotW, pad.top + plotH);
+            ctx.lineTo(pad.left, pad.top + plotH);
             ctx.closePath();
-            ctx.fillStyle = s.color;
             ctx.fill();
-            startAngle += sliceAngle;
         });
-
-        // Inner circle for donut
-        ctx.beginPath();
-        ctx.arc(cx, cy, radius * 0.52, 0, Math.PI * 2);
-        ctx.fillStyle = "#fafafa";
-        ctx.fill();
-
-        // Center text
-        ctx.fillStyle = "#111";
-        ctx.font = '600 13px "SF Mono", "Roboto Mono", Menlo, monospace';
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.fillText(fmt(total), cx, cy - 6);
-        ctx.font = '600 9px -apple-system, system-ui, sans-serif';
-        ctx.fillStyle = "#888";
-        ctx.letterSpacing = "0.05em";
-        ctx.fillText("TOTAL COST", cx, cy + 8);
 
         // Legend
-        var legendX = W * 0.65;
-        var legendY = cy - slices.length * 13;
+        ctx.font = "12px system-ui, sans-serif";
         ctx.textAlign = "left";
         ctx.textBaseline = "middle";
-        ctx.font = '600 10px -apple-system, system-ui, sans-serif';
-
-        slices.forEach(function (s, i) {
-            var ly = legendY + i * 26;
-            ctx.fillStyle = s.color;
-            ctx.fillRect(legendX, ly - 5, 12, 10);
-
-            ctx.fillStyle = "#111";
-            ctx.fillText(s.label, legendX + 18, ly);
-
-            ctx.fillStyle = "#888";
-            ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
-            ctx.fillText(fmt(s.value) + " (" + (s.value / total * 100).toFixed(1) + "%)", legendX + 18, ly + 13);
-            ctx.font = '600 10px -apple-system, system-ui, sans-serif';
+        var legendX = pad.left + 10;
+        var legendY = pad.top + 12;
+        results.forEach(function (r, i) {
+            var color = colors[i % colors.length];
+            ctx.fillStyle = color.line;
+            ctx.fillRect(legendX, legendY - 5, 14, 10);
+            ctx.fillStyle = "#555";
+            ctx.fillText(r.years + " yr", legendX + 20, legendY);
+            legendX += 70;
         });
     }
 
-    // --- Amortization schedule ---
-
-    function renderSchedule(sim) {
-        scheduleSection.style.display = "block";
-        var rows = sim.schedule;
-
-        if (scheduleMode === "annual") {
-            var byYear = {};
-            rows.forEach(function (r) {
-                var key = r.year;
-                if (!byYear[key]) byYear[key] = { year: key, termIndex: r.termIndex, payment: 0, principal: 0, interest: 0, tax: 0, insurance: 0, hoa: 0, pmi: 0, balance: 0 };
-                byYear[key].payment += r.payment;
-                byYear[key].principal += r.principal;
-                byYear[key].interest += r.interest;
-                byYear[key].tax += r.tax;
-                byYear[key].insurance += r.insurance;
-                byYear[key].hoa += r.hoa;
-                byYear[key].pmi += r.pmi;
-                byYear[key].balance = r.balance;
-            });
-            var yearRows = Object.keys(byYear).sort(function (a, b) { return a - b; }).map(function (k) { return byYear[k]; });
-
-            scheduleTableHead.innerHTML = "<tr><th>Year</th><th>Payment</th><th>Principal</th><th>Interest</th>" +
-                (sim.totalPMI > 0 ? "<th>" + sim.pmiLabel + "</th>" : "") +
-                "<th>Tax</th><th>Ins.</th><th>" + (country === "ca" ? "Condo" : "HOA") + "</th><th>Balance</th></tr>";
-
-            var html = "";
-            var prevTerm = -1;
-            yearRows.forEach(function (r) {
-                var cls = r.termIndex !== prevTerm ? ' class="term-boundary"' : "";
-                prevTerm = r.termIndex;
-                html += "<tr" + cls + ">" +
-                    "<td>" + r.year + "</td>" +
-                    "<td>" + fmt(r.payment) + "</td>" +
-                    "<td>" + fmt(r.principal) + "</td>" +
-                    "<td>" + fmt(r.interest) + "</td>" +
-                    (sim.totalPMI > 0 ? "<td>" + fmt(r.pmi) + "</td>" : "") +
-                    "<td>" + fmt(r.tax) + "</td>" +
-                    "<td>" + fmt(r.insurance) + "</td>" +
-                    "<td>" + fmt(r.hoa) + "</td>" +
-                    "<td>" + fmt(r.balance) + "</td>" +
-                    "</tr>";
-            });
-            scheduleTableBody.innerHTML = html;
-        } else {
-            scheduleTableHead.innerHTML = "<tr><th>Date</th><th>Payment</th><th>Principal</th><th>Interest</th>" +
-                (sim.totalPMI > 0 ? "<th>" + sim.pmiLabel + "</th>" : "") +
-                "<th>Balance</th></tr>";
-
-            var html = "";
-            var prevTerm = -1;
-            rows.forEach(function (r) {
-                var cls = r.termIndex !== prevTerm ? ' class="term-boundary"' : "";
-                prevTerm = r.termIndex;
-                html += "<tr" + cls + ">" +
-                    "<td>" + monthNames[r.month] + " " + r.year + "</td>" +
-                    "<td>" + fmt(r.payment) + "</td>" +
-                    "<td>" + fmt(r.principal) + "</td>" +
-                    "<td>" + fmt(r.interest) + "</td>" +
-                    (sim.totalPMI > 0 ? "<td>" + fmt(r.pmi) + "</td>" : "") +
-                    "<td>" + fmt(r.balance) + "</td>" +
-                    "</tr>";
-            });
-            scheduleTableBody.innerHTML = html;
-        }
-    }
-
-    // Schedule toggle
-    btnMonthly.addEventListener("click", function () {
-        scheduleMode = "monthly";
-        btnMonthly.classList.add("active");
-        btnAnnual.classList.remove("active");
-        if (lastSimResult) renderSchedule(lastSimResult);
+    // Toggle buttons
+    toggleButtons.forEach(function (btn) {
+        btn.addEventListener("click", function () {
+            btn.classList.toggle("active");
+            btn.setAttribute("aria-pressed", btn.classList.contains("active"));
+            render();
+        });
     });
 
-    btnAnnual.addEventListener("click", function () {
-        scheduleMode = "annual";
-        btnAnnual.classList.add("active");
-        btnMonthly.classList.remove("active");
-        if (lastSimResult) renderSchedule(lastSimResult);
-    });
+    // Input listeners
+    principalInput.addEventListener("input", render);
+    rateInput.addEventListener("input", render);
 
-    // --- Event bindings ---
-
-    [amortInput, paymentIncreaseInput, lumpSumAnnualInput, lumpSumTermInput,
-     propertyTaxInput, homeInsuranceInput, hoaInput, pmiInput, startYearInput].forEach(function (el) {
-        el.addEventListener("input", render);
-    });
-
-    startMonthInput.addEventListener("change", render);
-
+    // Redraw chart on resize
     var resizeTimer;
     window.addEventListener("resize", function () {
         clearTimeout(resizeTimer);
-        resizeTimer = setTimeout(function () { if (lastSimResult) render(); }, 150);
+        resizeTimer = setTimeout(render, 150);
     });
 
-    // --- Init ---
-
-    var saved = loadState();
-    if (saved && applyState(saved)) {
-        // Restored from localStorage
-    } else {
-        terms = countryConfig.ca.defaultTerms.map(function (t) { return { years: t.years, rate: t.rate, schedule: t.schedule }; });
-    }
-    syncLoan();
-    renderTerms();
-    renderCountryInfo();
-    loadCollapsedState();
+    // Initial render
     render();
-
-    // Clear all button
-    btnClear.addEventListener("click", function () {
-        clearState();
-        try { localStorage.removeItem(LS_KEY + "-collapsed"); } catch (e) {}
-        country = "ca";
-        btnCA.classList.add("active");
-        btnUS.classList.remove("active");
-        var cfg = countryConfig.ca;
-        pmiLabel.textContent = cfg.insuranceLabel;
-        hoaLabel.textContent = cfg.hoaLabel;
-        propertyTaxLabel.textContent = cfg.taxLabel;
-        amortInput.max = cfg.maxAmort;
-
-        homeValueInput.value = 500000;
-        downPaymentInput.value = 100000;
-        amortInput.value = cfg.defaultAmort;
-        paymentIncreaseInput.value = 0;
-        lumpSumAnnualInput.value = 0;
-        lumpSumTermInput.value = 0;
-        propertyTaxInput.value = 3500;
-        homeInsuranceInput.value = 1200;
-        hoaInput.value = 0;
-        pmiInput.value = 0;
-        startMonthInput.value = 5;
-        startYearInput.value = 2026;
-
-        terms = cfg.defaultTerms.map(function (t) { return { years: t.years, rate: t.rate, schedule: t.schedule }; });
-
-        // Reset collapsibles to collapsed
-        Object.keys(collapsibles).forEach(function (key) {
-            collapsibles[key].body.classList.add("collapsed");
-            collapsibles[key].arrow.classList.remove("open");
-        });
-
-        renderTerms();
-        syncLoan();
-        renderCountryInfo();
-        render();
-    });
 })();

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -172,17 +172,6 @@
         return "monthly";
     }
 
-    // Canadian mortgage: effective monthly rate from semi-annual compounding
-    // rate_semi = annualRate/2, effective monthly = (1 + rate_semi)^^(2/12) - 1
-    function effectiveMonthlyRate(annualRate, compounding) {
-        if (compounding === "semi-annual") {
-            var semiRate = annualRate / 100 / 2;
-            return Math.pow(1 + semiRate, 1 / 6) - 1;
-        }
-        // US: monthly compounding
-        return annualRate / 100 / 12;
-    }
-
     function calcBasePayment(principal, annualRate, amortYears, schedule, compounding) {
         var ppy = schedulePaymentsPerYear(schedule);
         var n = amortYears * ppy;

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -35,15 +35,16 @@
     var btnClear = document.getElementById("btn-clear");
     var hookLoan = document.getElementById("hook-loan");
     var hookInterest = document.getElementById("hook-interest");
+    var rateOptimisticInput = document.getElementById("rate-optimistic");
+    var ratePessimisticInput = document.getElementById("rate-pessimistic");
 
     // Collapsible sections
     var collapsibles = {
         prepay: { toggle: document.getElementById("toggle-prepay"), body: document.getElementById("body-prepay"), arrow: document.getElementById("arrow-prepay") },
-        costs:  { toggle: document.getElementById("toggle-costs"),  body: document.getElementById("body-costs"),  arrow: document.getElementById("arrow-arrow-costs") },
+        costs:  { toggle: document.getElementById("toggle-costs"),  body: document.getElementById("body-costs"),  arrow: document.getElementById("arrow-costs") },
+        scenarios: { toggle: document.getElementById("toggle-scenarios"), body: document.getElementById("body-scenarios"), arrow: document.getElementById("arrow-scenarios") },
         date:   { toggle: document.getElementById("toggle-date"),   body: document.getElementById("body-date"),   arrow: document.getElementById("arrow-date") },
     };
-    // Fix arrow-costs id
-    collapsibles.costs.arrow = document.getElementById("arrow-costs");
 
     // Collapsible toggle handlers
     Object.keys(collapsibles).forEach(function (key) {
@@ -237,6 +238,8 @@
                 startMonth: startMonthInput.value,
                 startYear: startYearInput.value,
                 scheduleMode: scheduleMode,
+                rateOptimistic: rateOptimisticInput.value,
+                ratePessimistic: ratePessimisticInput.value,
                 terms: terms,
             };
             localStorage.setItem(LS_KEY, JSON.stringify(state));
@@ -284,6 +287,8 @@
             btnMonthly.classList.toggle("active", scheduleMode === "monthly");
             btnAnnual.classList.toggle("active", scheduleMode === "annual");
         }
+        if (s.rateOptimistic !== undefined) rateOptimisticInput.value = s.rateOptimistic;
+        if (s.ratePessimistic !== undefined) ratePessimisticInput.value = s.ratePessimistic;
         if (s.terms && Array.isArray(s.terms) && s.terms.length > 0) {
             terms = s.terms;
         }
@@ -678,6 +683,44 @@
                 '</div>';
         });
 
+        // Scenario comparison
+        var optOffset = parseFloat(rateOptimisticInput.value) || 0;
+        var pessOffset = parseFloat(ratePessimisticInput.value) || 0;
+        if (optOffset !== 0 || pessOffset !== 0) {
+            var optTerms = terms.map(function (t) { return { years: t.years, rate: Math.max(0, t.rate + optOffset), schedule: t.schedule }; });
+            var pessTerms = terms.map(function (t) { return { years: t.years, rate: t.rate + pessOffset, schedule: t.schedule }; });
+            var simOpt = simulateMortgage(principal, amort, optTerms, annualIncrease, lumpAnnual, lumpTerm, annualTax, annualInsurance, monthlyHOA, annualPMI, startMonth, startYear);
+            var simPess = simulateMortgage(principal, amort, pessTerms, annualIncrease, lumpAnnual, lumpTerm, annualTax, annualInsurance, monthlyHOA, annualPMI, startMonth, startYear);
+
+            html +=
+                '<div class="scenario-compare">' +
+                '<table class="scenario-table">' +
+                '<thead><tr><th></th>' +
+                '<th><span class="scenario-label opt">Optimistic ' + fmtPct(optOffset) + '</span></th>' +
+                '<th>Base</th>' +
+                '<th><span class="scenario-label pess">Pessimistic +' + fmtPct(pessOffset) + '</span></th>' +
+                '</tr></thead><tbody>' +
+                '<tr><td>Monthly Payment</td><td>' + fmtFull(simOpt.termResults[0].basePayment) + '</td><td>' + fmtFull(sim.termResults[0].basePayment) + '</td><td>' + fmtFull(simPess.termResults[0].basePayment) + '</td></tr>' +
+                '<tr><td>Total Interest</td><td>' + fmt(simOpt.totalInterest) + '</td><td>' + fmt(sim.totalInterest) + '</td><td>' + fmt(simPess.totalInterest) + '</td></tr>' +
+                '<tr><td>Total Cost</td><td>' + fmt(simOpt.totalAllIn) + '</td><td>' + fmt(sim.totalAllIn) + '</td><td>' + fmt(simPess.totalAllIn) + '</td></tr>' +
+                '<tr><td>Interest Share</td><td>' + fmtPct(simOpt.totalPaid > 0 ? simOpt.totalInterest / simOpt.totalPaid * 100 : 0) + '</td><td>' + fmtPct(sim.totalPaid > 0 ? sim.totalInterest / sim.totalPaid * 100 : 0) + '</td><td>' + fmtPct(simPess.totalPaid > 0 ? simPess.totalInterest / simPess.totalPaid * 100 : 0) + '</td></tr>' +
+                '<tr><td>Paid Off</td><td>' + (simOpt.paidOff ? 'Yes' : 'No') + '</td><td>' + (sim.paidOff ? 'Yes' : 'No') + '</td><td>' + (simPess.paidOff ? 'Yes' : 'No') + '</td></tr>' +
+                '</tbody></table></div>';
+        }
+
+        // Missing years to amortization
+        var totalTermYears = 0;
+        terms.forEach(function (t) { totalTermYears += t.years; });
+        var missingYears = amort - totalTermYears;
+        if (missingYears > 0) {
+            var remainingBalance = sim.paidOff ? 0 : sim.termResults[sim.termResults.length - 1].balanceAtEnd;
+            html += '<div class="missing-years">' +
+                'Defined terms cover <strong>' + totalTermYears + ' of ' + amort + ' years</strong> of the amortization. ' +
+                '<strong>' + missingYears + ' years</strong> remain after the last term with a balance of <strong>' + fmt(remainingBalance) + '</strong>. ' +
+                'You will need to renew at whatever rate is available then.' +
+                '</div>';
+        }
+
         if (!sim.paidOff) {
             html += '<p class="hint" style="margin-top:0.5rem;color:#c0392b;font-size:0.8125rem;font-weight:600;">Mortgage not fully paid after all terms. Remaining balance: ' + fmt(sim.termResults[sim.termResults.length - 1].balanceAtEnd) + '</p>';
         }
@@ -957,7 +1000,8 @@
     // --- Event bindings ---
 
     [amortInput, paymentIncreaseInput, lumpSumAnnualInput, lumpSumTermInput,
-     propertyTaxInput, homeInsuranceInput, hoaInput, pmiInput, startYearInput].forEach(function (el) {
+     propertyTaxInput, homeInsuranceInput, hoaInput, pmiInput, startYearInput,
+     rateOptimisticInput, ratePessimisticInput].forEach(function (el) {
         el.addEventListener("input", render);
     });
 
@@ -1008,6 +1052,8 @@
         pmiInput.value = 0;
         startMonthInput.value = 5;
         startYearInput.value = 2026;
+        rateOptimisticInput.value = -1;
+        ratePessimisticInput.value = 2;
 
         terms = cfg.defaultTerms.map(function (t) { return { years: t.years, rate: t.rate, schedule: t.schedule }; });
 

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -652,7 +652,7 @@
             var biweeklyAnnual = biweeklyPay * 26;
             var monthlyAnnual = monthlyPay * 12;
             var extraPerYear = biweeklyAnnual - monthlyAnnual;
-            html += '<div class="biweekly-compare">Switch to bi-weekly payments of <strong>' + fmtFull(biweeklyPay) + '</strong>? That equals <strong>' + fmt(extraPerYear) + ' extra/year</strong> going to principal, cutting years off your mortgage.</div>';
+            html += '<div class="biweekly-compare">Switch to bi-weekly payments of <strong>' + fmtFull(biweeklyPay) + '</strong>? That puts <strong>' + fmt(extraPerYear) + ' extra/year</strong> toward your mortgage, cutting years off the amortization.</div>';
         }
 
         // Per-term breakdown

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -740,6 +740,10 @@
 
     // --- Interest per term bar chart ---
 
+    function cssVar(name) {
+        return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    }
+
     function drawInterestChart(sim) {
         var canvas = document.getElementById("interestChart");
         var dpr = window.devicePixelRatio || 1;
@@ -771,10 +775,10 @@
         var barWidth = Math.min(barGroupWidth * 0.55, 60);
 
         // Grid
-        ctx.strokeStyle = "#e2e2e2";
+        ctx.strokeStyle = cssVar("--chart-line");
         ctx.lineWidth = 1;
         ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
-        ctx.fillStyle = "#888";
+        ctx.fillStyle = cssVar("--chart-text");
         ctx.textAlign = "right";
         ctx.textBaseline = "middle";
 
@@ -798,19 +802,19 @@
             ctx.fillRect(x, pad.top + plotH - bHeight, barWidth, bHeight);
 
             // Value on top
-            ctx.fillStyle = "#555";
+            ctx.fillStyle = cssVar("--text-2");
             ctx.textAlign = "center";
             ctx.textBaseline = "bottom";
             ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
             ctx.fillText(fmt(t.interestPaid), cx, pad.top + plotH - bHeight - 4);
 
             // Term label
-            ctx.fillStyle = "#555";
+            ctx.fillStyle = cssVar("--text-2");
             ctx.textBaseline = "top";
             ctx.font = '600 10px -apple-system, system-ui, sans-serif';
             ctx.fillText("TERM " + (i + 1), cx, pad.top + plotH + 6);
             ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
-            ctx.fillStyle = "#888";
+            ctx.fillStyle = cssVar("--text-3");
             ctx.fillText(t.years + "yr @ " + t.rate + "%", cx, pad.top + plotH + 20);
         });
 
@@ -818,7 +822,7 @@
         ctx.save();
         ctx.translate(14, pad.top + plotH / 2);
         ctx.rotate(-Math.PI / 2);
-        ctx.fillStyle = "#888";
+        ctx.fillStyle = cssVar("--chart-text");
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         ctx.font = '600 10px -apple-system, system-ui, sans-serif';
@@ -880,17 +884,17 @@
         // Inner circle for donut
         ctx.beginPath();
         ctx.arc(cx, cy, radius * 0.52, 0, Math.PI * 2);
-        ctx.fillStyle = "#fafafa";
+        ctx.fillStyle = cssVar("--bg");
         ctx.fill();
 
         // Center text
-        ctx.fillStyle = "#111";
+        ctx.fillStyle = cssVar("--text");
         ctx.font = '600 13px "SF Mono", "Roboto Mono", Menlo, monospace';
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         ctx.fillText(fmt(total), cx, cy - 6);
         ctx.font = '600 9px -apple-system, system-ui, sans-serif';
-        ctx.fillStyle = "#888";
+        ctx.fillStyle = cssVar("--chart-text");
         ctx.fillText("TOTAL COST", cx, cy + 8);
 
         // Legend
@@ -905,10 +909,10 @@
             ctx.fillStyle = s.color;
             ctx.fillRect(legendX, ly - 5, 12, 10);
 
-            ctx.fillStyle = "#111";
+            ctx.fillStyle = cssVar("--text");
             ctx.fillText(s.label, legendX + 18, ly);
 
-            ctx.fillStyle = "#888";
+            ctx.fillStyle = cssVar("--chart-text");
             ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
             ctx.fillText(fmt(s.value) + " (" + (s.value / total * 100).toFixed(1) + "%)", legendX + 18, ly + 13);
             ctx.font = '600 10px -apple-system, system-ui, sans-serif';
@@ -1012,6 +1016,14 @@
         clearTimeout(resizeTimer);
         resizeTimer = setTimeout(function () { if (lastSimResult) render(); }, 150);
     });
+
+    // Re-render charts when theme changes (canvas doesn't respond to CSS)
+    new MutationObserver(function () {
+        if (lastSimResult) {
+            drawInterestChart(lastSimResult);
+            drawPieChart(lastSimResult);
+        }
+    }).observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
 
     // --- Init ---
 

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -188,23 +188,25 @@
         var n = amortYears * ppy;
         if (principal <= 0 || n <= 0) return 0;
 
-        var r;
-        if (compounding === "semi-annual") {
-            // For Canadian mortgages, convert to effective period rate
-            var monthlyRate = effectiveMonthlyRate(annualRate, "semi-annual");
-            if (schedule === "monthly") {
-                r = monthlyRate;
-            } else if (schedule === "biweekly") {
-                r = Math.pow(1 + monthlyRate, 1 / 2) - 1;
-            } else {
-                r = Math.pow(1 + monthlyRate, 1 / 4) - 1;
-            }
-        } else {
-            r = annualRate / 100 / ppy;
-        }
+        var r = effectivePeriodRate(annualRate, schedule, compounding);
 
         if (r === 0) return principal / n;
         return principal * (r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1);
+    }
+
+    function effectivePeriodRate(annualRate, schedule, compounding) {
+        if (compounding === "semi-annual") {
+            // Canadian: semi-annual compounding
+            // Semi rate = annualRate/2, then derive period rate from half-year
+            // Monthly: 6 periods per half-year → (1+semiRate)^(1/6) - 1
+            // Bi-weekly: 13 periods per half-year → (1+semiRate)^(1/13) - 1
+            // Weekly: 26 periods per half-year → (1+semiRate)^(1/26) - 1
+            var semiRate = annualRate / 100 / 2;
+            var periodsPerHalfYear = schedule === "monthly" ? 6 : schedule === "biweekly" ? 13 : 26;
+            return Math.pow(1 + semiRate, 1 / periodsPerHalfYear) - 1;
+        }
+        // US: monthly compounding
+        return annualRate / 100 / ppy;
     }
 
     function addCommas(n) {
@@ -489,20 +491,7 @@
             var term = termDefs[ti];
             var ppy = schedulePaymentsPerYear(term.schedule);
 
-            // Effective period rate
-            var r;
-            if (compounding === "semi-annual") {
-                var monthlyRate = effectiveMonthlyRate(term.rate, "semi-annual");
-                if (term.schedule === "monthly") {
-                    r = monthlyRate;
-                } else if (term.schedule === "biweekly") {
-                    r = Math.pow(1 + monthlyRate, 1 / 2) - 1;
-                } else {
-                    r = Math.pow(1 + monthlyRate, 1 / 4) - 1;
-                }
-            } else {
-                r = term.rate / 100 / ppy;
-            }
+            var r = effectivePeriodRate(term.rate, term.schedule, compounding);
 
             var termPayments = term.years * ppy;
 

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -849,7 +849,6 @@
         ctx.fillText(fmt(total), cx, cy - 6);
         ctx.font = '600 9px -apple-system, system-ui, sans-serif';
         ctx.fillStyle = "#888";
-        ctx.letterSpacing = "0.05em";
         ctx.fillText("TOTAL COST", cx, cy + 8);
 
         // Legend

--- a/static/tools/multi-term-mortgage-calculator/style.css
+++ b/static/tools/multi-term-mortgage-calculator/style.css
@@ -4,172 +4,524 @@
     box-sizing: border-box;
 }
 
+:root {
+    --bg: #fafafa;
+    --surface: #fff;
+    --text: #111;
+    --text-2: #555;
+    --text-3: #888;
+    --border: #e2e2e2;
+    --border-focus: #111;
+    --accent: #111;
+    --accent-soft: #f3f3f3;
+    --radius: 2px;
+    --mono: "SF Mono", "Roboto Mono", "Menlo", monospace;
+}
+
 body {
-    font-family: system-ui, -apple-system, sans-serif;
-    max-width: 720px;
+    font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
+    max-width: 780px;
     margin: 0 auto;
-    padding: 1.5rem 1rem 3rem;
-    line-height: 1.5;
-    color: #222;
-    background: #fff;
+    padding: 2.5rem 1.5rem 4rem;
+    line-height: 1.55;
+    color: var(--text);
+    background: var(--bg);
+    -webkit-font-smoothing: antialiased;
 }
 
-h1 {
+/* Hook */
+.hook {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.hook-line {
     font-size: 1.5rem;
-    margin-bottom: 0.15rem;
+    font-weight: 300;
+    line-height: 1.3;
+    letter-spacing: -0.02em;
+    color: var(--text-2);
 }
 
-.subtitle {
-    color: #666;
-    font-size: 0.95rem;
+.hook-value {
+    font-family: var(--mono);
+    font-weight: 500;
+    color: var(--text);
+}
+
+.hook-emphasis {
+    color: var(--text);
+    font-weight: 700;
+    font-size: 1.55rem;
+}
+
+.hook-sub {
+    font-size: 0.8125rem;
+    color: var(--text-3);
+    margin-top: 0.35rem;
+    letter-spacing: 0.02em;
+}
+
+/* Header row */
+.header-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.country-toggle {
+    display: inline-flex;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.country-btn {
+    border: none;
+    background: var(--surface);
+    padding: 0.3rem 0.9rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    cursor: pointer;
+    color: var(--text-2);
+    transition: all 0.1s;
+}
+
+.country-btn.active {
+    background: var(--accent);
+    color: #fff;
+}
+
+.country-btn:not(.active):hover {
+    background: var(--accent-soft);
+    color: var(--text);
+}
+
+.clear-btn {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.3rem 0.75rem;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-3);
+    cursor: pointer;
+    transition: all 0.1s;
+}
+
+.clear-btn:hover {
+    border-color: var(--text);
+    color: var(--text);
+}
+
+/* Country info */
+.country-info {
+    margin-bottom: 1.5rem;
+    font-size: 0.75rem;
+    line-height: 1.55;
+    color: var(--text-2);
+}
+
+.country-info ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.country-info li {
+    padding-left: 0.75rem;
+    position: relative;
+    margin-bottom: 0.25rem;
+}
+
+.country-info li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.55em;
+    width: 3px;
+    height: 3px;
+    background: var(--text-3);
+    border-radius: 50%;
+}
+
+.country-info li strong {
+    color: var(--text);
+    font-weight: 600;
+}
+
+/* Sections */
+.section {
     margin-bottom: 1.5rem;
 }
 
-/* Input section */
-.input-section {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1rem;
-    margin-bottom: 1.25rem;
+.section-title {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-3);
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+/* Core row */
+.core-row {
+    margin-bottom: 0.75rem;
+}
+
+/* Input rows */
+.input-row {
+    display: flex;
+    gap: 0.625rem;
+    flex-wrap: wrap;
+}
+
+.input-row .field {
+    flex: 1;
+    min-width: 130px;
 }
 
 .field label {
     display: block;
-    font-size: 0.85rem;
-    font-weight: 600;
-    margin-bottom: 0.3rem;
+    font-size: 0.6875rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    margin-bottom: 0.25rem;
+    color: var(--text-2);
 }
 
 .input-wrap {
     display: flex;
     align-items: center;
-    border: 1px solid #ccc;
-    border-radius: 4px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
     overflow: hidden;
-    background: #fff;
+    background: var(--surface);
+    transition: border-color 0.1s;
 }
 
 .input-wrap:focus-within {
-    border-color: #4a90d9;
-    box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.2);
+    border-color: var(--border-focus);
+    box-shadow: none;
+}
+
+.input-wrap input[readonly] {
+    background: var(--accent-soft);
+    color: var(--text-2);
+    cursor: default;
 }
 
 .input-wrap input {
     flex: 1;
     border: none;
     padding: 0.5rem 0.6rem;
-    font-size: 1rem;
+    font-size: 0.875rem;
+    font-family: var(--mono);
+    font-weight: 400;
     outline: none;
     width: 100%;
     min-width: 0;
+    color: var(--text);
 }
 
 .prefix, .suffix {
-    padding: 0.5rem 0.6rem;
-    background: #f5f5f5;
-    color: #666;
-    font-size: 0.9rem;
-    border-right: 1px solid #ccc;
+    padding: 0.5rem 0.55rem;
+    background: var(--accent-soft);
+    color: var(--text-3);
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+    letter-spacing: 0;
+}
+
+.prefix {
+    border-right: 1px solid var(--border);
 }
 
 .suffix {
-    border-right: none;
-    border-left: 1px solid #ccc;
+    border-left: 1px solid var(--border);
 }
 
-/* Term toggles */
-.terms-section {
-    margin-bottom: 1.5rem;
-}
-
-.terms-section label {
-    display: block;
-    font-size: 0.85rem;
-    font-weight: 600;
-    margin-bottom: 0.4rem;
-}
-
-.term-toggles {
-    display: flex;
-    gap: 0.4rem;
-    flex-wrap: wrap;
-}
-
-.term-toggle {
-    padding: 0.35rem 0.9rem;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    background: #fff;
+select {
+    width: 100%;
+    padding: 0.5rem 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    background: var(--surface);
     cursor: pointer;
-    font-size: 0.85rem;
-    transition: all 0.15s;
+    color: var(--text);
 }
 
-.term-toggle:hover {
-    border-color: #999;
+select:focus {
+    border-color: var(--border-focus);
+    box-shadow: none;
+    outline: none;
 }
 
-.term-toggle.active {
-    background: #222;
-    color: #fff;
-    border-color: #222;
+/* Collapsible sections */
+.section-toggle {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    text-align: left;
+}
+
+.section-toggle .section-title {
+    margin-bottom: 0;
+    padding-bottom: 0;
+    border-bottom: none;
+}
+
+.toggle-arrow {
+    font-size: 0.625rem;
+    color: var(--text-3);
+    transition: transform 0.15s;
+    display: inline-block;
+}
+
+.toggle-arrow.open {
+    transform: rotate(180deg);
+}
+
+.section-body {
+    overflow: hidden;
+    transition: max-height 0.25s ease, opacity 0.2s ease, margin 0.2s ease;
+    max-height: 500px;
+    opacity: 1;
+    margin-top: 0.75rem;
+}
+
+.section-body.collapsed {
+    max-height: 0;
+    opacity: 0;
+    margin-top: 0;
+}
+
+/* PMI row */
+.pmi-row {
+    margin-top: 0.5rem;
+}
+
+.pmi-row .field {
+    max-width: 200px;
+}
+
+.hint {
+    font-size: 0.6875rem;
+    color: var(--text-3);
+    margin-top: 0.4rem;
+    line-height: 1.45;
+}
+
+/* Term cards */
+.terms-list {
+    margin-bottom: 0.375rem;
+}
+
+.term-card {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.75rem 0.9rem;
+    margin-bottom: 0.375rem;
+    background: var(--surface);
+}
+
+.term-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.term-card-header h3 {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-2);
+}
+
+.remove-term {
+    background: none;
+    border: none;
+    color: var(--text-3);
+    font-size: 0.875rem;
+    cursor: pointer;
+    padding: 0 0.2rem;
+    line-height: 1;
+    transition: color 0.1s;
+}
+
+.remove-term:hover {
+    color: #c0392b;
+}
+
+.term-fields {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 0.5rem;
+}
+
+.term-fields .field {
+    min-width: 0;
+}
+
+.btn-link {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.4rem 0.8rem;
+    color: var(--text-2);
+    cursor: pointer;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    width: 100%;
+    transition: all 0.1s;
+}
+
+.btn-link:hover {
+    border-color: var(--text);
+    color: var(--text);
 }
 
 /* Results */
-.results {
-    display: grid;
-    gap: 0.75rem;
+.results-section {
+    display: none;
 }
 
-.result-card {
-    border: 1px solid #ddd;
-    border-radius: 6px;
-    padding: 0.9rem 1rem;
+.results-section.visible {
+    display: block;
 }
 
-.result-card h3 {
-    font-size: 0.95rem;
-    margin-bottom: 0.4rem;
-    color: #555;
-}
-
-.result-card .monthly {
-    font-size: 1.5rem;
-    font-weight: 700;
-}
-
-.result-card .monthly span {
-    font-size: 0.85rem;
-    font-weight: 400;
-    color: #888;
-}
-
-.result-details {
+.result-summary {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
-    gap: 0.4rem;
-    margin-top: 0.5rem;
-    font-size: 0.82rem;
-    color: #555;
+    gap: 0.375rem;
+    margin-bottom: 1.25rem;
 }
 
-.result-details dt {
-    color: #999;
+.summary-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.75rem 0.9rem;
+    text-align: left;
 }
 
-.result-details dd {
+.summary-card .label {
+    font-size: 0.625rem;
     font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-3);
+    margin-bottom: 0.2rem;
+}
+
+.summary-card .value {
+    font-size: 1.125rem;
+    font-weight: 600;
+    font-family: var(--mono);
+    letter-spacing: -0.02em;
+    color: var(--text);
+}
+
+.summary-card.accent {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+}
+
+.summary-card.accent .label {
+    color: rgba(255,255,255,0.55);
+}
+
+.summary-card.accent .value {
+    color: #fff;
+}
+
+.biweekly-compare {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.65rem 0.9rem;
+    margin-bottom: 1.25rem;
+    font-size: 0.8125rem;
+    color: var(--text-2);
+    line-height: 1.5;
+}
+
+.biweekly-compare strong {
+    color: var(--text);
+    font-weight: 600;
+}
+
+.term-result {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.65rem 0.9rem;
+    margin-bottom: 0.375rem;
+    background: var(--surface);
+}
+
+.term-result h4 {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: var(--text-2);
+    margin-bottom: 0.4rem;
+}
+
+.term-result-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 0.3rem 0.75rem;
+    font-size: 0.8125rem;
+}
+
+.term-result-grid dt {
+    color: var(--text-3);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+}
+
+.term-result-grid dd {
+    font-weight: 500;
+    font-family: var(--mono);
+    font-size: 0.8125rem;
+    letter-spacing: -0.01em;
     margin-left: 0;
+    color: var(--text);
 }
 
-/* Chart */
+/* Charts */
 .chart-section {
-    margin-top: 2rem;
+    display: none;
 }
 
-.chart-section h2 {
-    font-size: 1rem;
-    margin-bottom: 0.75rem;
+.chart-section.visible {
+    display: block;
 }
 
 canvas {
@@ -177,12 +529,111 @@ canvas {
     height: 280px;
 }
 
+/* Schedule toggle */
+.schedule-toggle {
+    display: inline-flex;
+    gap: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.toggle-btn {
+    border: none;
+    background: var(--surface);
+    padding: 0.2rem 0.6rem;
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    cursor: pointer;
+    color: var(--text-2);
+    transition: all 0.1s;
+}
+
+.toggle-btn.active {
+    background: var(--accent);
+    color: #fff;
+}
+
+/* Amortization table */
+.table-wrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+}
+
+#schedule-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.75rem;
+    font-family: var(--mono);
+}
+
+#schedule-table th {
+    background: var(--accent-soft);
+    text-align: right;
+    padding: 0.4rem 0.6rem;
+    border-bottom: 1px solid var(--border);
+    font-weight: 600;
+    font-size: 0.625rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--text-2);
+    white-space: nowrap;
+    position: sticky;
+    top: 0;
+}
+
+#schedule-table th:first-child {
+    text-align: left;
+}
+
+#schedule-table td {
+    text-align: right;
+    padding: 0.35rem 0.6rem;
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+    color: var(--text);
+}
+
+#schedule-table td:first-child {
+    text-align: left;
+    color: var(--text-2);
+}
+
+#schedule-table tbody tr.term-boundary td {
+    border-top: 1px solid var(--text);
+}
+
+/* Footer */
+.tool-footer {
+    margin-top: 3rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.6875rem;
+    line-height: 1.55;
+    color: var(--text-3);
+}
+
 /* Responsive */
 @media (max-width: 500px) {
-    .input-section {
-        grid-template-columns: 1fr;
+    body {
+        padding: 1.25rem 0.75rem 3rem;
     }
-    .result-details {
+
+    .hook-line {
+        font-size: 1.2rem;
+    }
+
+    .term-fields {
+        grid-template-columns: 1fr 1fr;
+    }
+    .result-summary {
+        grid-template-columns: 1fr 1fr;
+    }
+    .term-result-grid {
         grid-template-columns: 1fr 1fr;
     }
 }

--- a/static/tools/multi-term-mortgage-calculator/style.css
+++ b/static/tools/multi-term-mortgage-calculator/style.css
@@ -271,6 +271,14 @@ select:focus {
     outline: none;
 }
 
+/* Scenario hint */
+.scenario-hint {
+    font-size: 0.6875rem;
+    color: var(--text-3);
+    margin-bottom: 0.5rem;
+    line-height: 1.45;
+}
+
 /* Collapsible sections */
 .section-toggle {
     display: flex;
@@ -513,6 +521,85 @@ select:focus {
     letter-spacing: -0.01em;
     margin-left: 0;
     color: var(--text);
+}
+
+/* Scenario comparison */
+.scenario-compare {
+    margin-bottom: 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.scenario-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8125rem;
+}
+
+.scenario-table th {
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-3);
+    padding: 0.5rem 0.7rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--accent-soft);
+    text-align: right;
+    white-space: nowrap;
+}
+
+.scenario-table th:first-child {
+    text-align: left;
+}
+
+.scenario-table td {
+    padding: 0.4rem 0.7rem;
+    border-bottom: 1px solid var(--border);
+    text-align: right;
+    font-family: var(--mono);
+    font-size: 0.8125rem;
+    letter-spacing: -0.01em;
+    white-space: nowrap;
+}
+
+.scenario-table td:first-child {
+    text-align: left;
+    font-family: -apple-system, system-ui, sans-serif;
+    color: var(--text-2);
+}
+
+.scenario-table tr:last-child td {
+    border-bottom: none;
+}
+
+.scenario-label {
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.scenario-label.opt { color: #2a7a4a; }
+.scenario-label.pess { color: #a83232; }
+
+/* Missing years */
+.missing-years {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.65rem 0.9rem;
+    margin-bottom: 1.25rem;
+    font-size: 0.8125rem;
+    color: var(--text-2);
+    line-height: 1.55;
+}
+
+.missing-years strong {
+    color: var(--text);
+    font-weight: 600;
+    font-family: var(--mono);
 }
 
 /* Charts */

--- a/static/tools/multi-term-mortgage-calculator/style.css
+++ b/static/tools/multi-term-mortgage-calculator/style.css
@@ -419,6 +419,17 @@ select:focus {
     line-height: 1.45;
 }
 
+.hint.warning {
+    color: #c0392b;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    margin-top: 0.5rem;
+}
+
+:root[data-theme="dark"] .hint.warning {
+    color: #e85555;
+}
+
 /* Term cards */
 .terms-list {
     margin-bottom: 0.375rem;
@@ -806,7 +817,7 @@ canvas {
 }
 
 #schedule-table tbody tr.term-boundary td {
-    border-top: 1px solid var(--text);
+    border-top: 2px solid var(--text-3);
 }
 
 /* Footer */

--- a/static/tools/multi-term-mortgage-calculator/style.css
+++ b/static/tools/multi-term-mortgage-calculator/style.css
@@ -4,524 +4,172 @@
     box-sizing: border-box;
 }
 
-:root {
-    --bg: #fafafa;
-    --surface: #fff;
-    --text: #111;
-    --text-2: #555;
-    --text-3: #888;
-    --border: #e2e2e2;
-    --border-focus: #111;
-    --accent: #111;
-    --accent-soft: #f3f3f3;
-    --radius: 2px;
-    --mono: "SF Mono", "Roboto Mono", "Menlo", monospace;
-}
-
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
-    max-width: 780px;
+    font-family: system-ui, -apple-system, sans-serif;
+    max-width: 720px;
     margin: 0 auto;
-    padding: 2.5rem 1.5rem 4rem;
-    line-height: 1.55;
-    color: var(--text);
-    background: var(--bg);
-    -webkit-font-smoothing: antialiased;
+    padding: 1.5rem 1rem 3rem;
+    line-height: 1.5;
+    color: #222;
+    background: #fff;
 }
 
-/* Hook */
-.hook {
-    margin-bottom: 2rem;
-    padding-bottom: 1.5rem;
-    border-bottom: 1px solid var(--border);
-}
-
-.hook-line {
+h1 {
     font-size: 1.5rem;
-    font-weight: 300;
-    line-height: 1.3;
-    letter-spacing: -0.02em;
-    color: var(--text-2);
+    margin-bottom: 0.15rem;
 }
 
-.hook-value {
-    font-family: var(--mono);
-    font-weight: 500;
-    color: var(--text);
-}
-
-.hook-emphasis {
-    color: var(--text);
-    font-weight: 700;
-    font-size: 1.55rem;
-}
-
-.hook-sub {
-    font-size: 0.8125rem;
-    color: var(--text-3);
-    margin-top: 0.35rem;
-    letter-spacing: 0.02em;
-}
-
-/* Header row */
-.header-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1rem;
-}
-
-.country-toggle {
-    display: inline-flex;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    overflow: hidden;
-}
-
-.country-btn {
-    border: none;
-    background: var(--surface);
-    padding: 0.3rem 0.9rem;
-    font-size: 0.75rem;
-    font-weight: 500;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    cursor: pointer;
-    color: var(--text-2);
-    transition: all 0.1s;
-}
-
-.country-btn.active {
-    background: var(--accent);
-    color: #fff;
-}
-
-.country-btn:not(.active):hover {
-    background: var(--accent-soft);
-    color: var(--text);
-}
-
-.clear-btn {
-    background: none;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0.3rem 0.75rem;
-    font-size: 0.6875rem;
-    font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--text-3);
-    cursor: pointer;
-    transition: all 0.1s;
-}
-
-.clear-btn:hover {
-    border-color: var(--text);
-    color: var(--text);
-}
-
-/* Country info */
-.country-info {
-    margin-bottom: 1.5rem;
-    font-size: 0.75rem;
-    line-height: 1.55;
-    color: var(--text-2);
-}
-
-.country-info ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-.country-info li {
-    padding-left: 0.75rem;
-    position: relative;
-    margin-bottom: 0.25rem;
-}
-
-.country-info li::before {
-    content: "";
-    position: absolute;
-    left: 0;
-    top: 0.55em;
-    width: 3px;
-    height: 3px;
-    background: var(--text-3);
-    border-radius: 50%;
-}
-
-.country-info li strong {
-    color: var(--text);
-    font-weight: 600;
-}
-
-/* Sections */
-.section {
+.subtitle {
+    color: #666;
+    font-size: 0.95rem;
     margin-bottom: 1.5rem;
 }
 
-.section-title {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--text-3);
-    margin-bottom: 0.75rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 1px solid var(--border);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-
-/* Core row */
-.core-row {
-    margin-bottom: 0.75rem;
-}
-
-/* Input rows */
-.input-row {
-    display: flex;
-    gap: 0.625rem;
-    flex-wrap: wrap;
-}
-
-.input-row .field {
-    flex: 1;
-    min-width: 130px;
+/* Input section */
+.input-section {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
 }
 
 .field label {
     display: block;
-    font-size: 0.6875rem;
-    font-weight: 500;
-    letter-spacing: 0.02em;
-    margin-bottom: 0.25rem;
-    color: var(--text-2);
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin-bottom: 0.3rem;
 }
 
 .input-wrap {
     display: flex;
     align-items: center;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
+    border: 1px solid #ccc;
+    border-radius: 4px;
     overflow: hidden;
-    background: var(--surface);
-    transition: border-color 0.1s;
+    background: #fff;
 }
 
 .input-wrap:focus-within {
-    border-color: var(--border-focus);
-    box-shadow: none;
-}
-
-.input-wrap input[readonly] {
-    background: var(--accent-soft);
-    color: var(--text-2);
-    cursor: default;
+    border-color: #4a90d9;
+    box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.2);
 }
 
 .input-wrap input {
     flex: 1;
     border: none;
     padding: 0.5rem 0.6rem;
-    font-size: 0.875rem;
-    font-family: var(--mono);
-    font-weight: 400;
+    font-size: 1rem;
     outline: none;
     width: 100%;
     min-width: 0;
-    color: var(--text);
 }
 
 .prefix, .suffix {
-    padding: 0.5rem 0.55rem;
-    background: var(--accent-soft);
-    color: var(--text-3);
-    font-size: 0.75rem;
-    font-weight: 500;
-    white-space: nowrap;
-    letter-spacing: 0;
-}
-
-.prefix {
-    border-right: 1px solid var(--border);
+    padding: 0.5rem 0.6rem;
+    background: #f5f5f5;
+    color: #666;
+    font-size: 0.9rem;
+    border-right: 1px solid #ccc;
 }
 
 .suffix {
-    border-left: 1px solid var(--border);
+    border-right: none;
+    border-left: 1px solid #ccc;
 }
 
-select {
-    width: 100%;
-    padding: 0.5rem 0.5rem;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    font-size: 0.8125rem;
-    font-weight: 500;
-    background: var(--surface);
-    cursor: pointer;
-    color: var(--text);
+/* Term toggles */
+.terms-section {
+    margin-bottom: 1.5rem;
 }
 
-select:focus {
-    border-color: var(--border-focus);
-    box-shadow: none;
-    outline: none;
-}
-
-/* Collapsible sections */
-.section-toggle {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 0;
-    text-align: left;
-}
-
-.section-toggle .section-title {
-    margin-bottom: 0;
-    padding-bottom: 0;
-    border-bottom: none;
-}
-
-.toggle-arrow {
-    font-size: 0.625rem;
-    color: var(--text-3);
-    transition: transform 0.15s;
-    display: inline-block;
-}
-
-.toggle-arrow.open {
-    transform: rotate(180deg);
-}
-
-.section-body {
-    overflow: hidden;
-    transition: max-height 0.25s ease, opacity 0.2s ease, margin 0.2s ease;
-    max-height: 500px;
-    opacity: 1;
-    margin-top: 0.75rem;
-}
-
-.section-body.collapsed {
-    max-height: 0;
-    opacity: 0;
-    margin-top: 0;
-}
-
-/* PMI row */
-.pmi-row {
-    margin-top: 0.5rem;
-}
-
-.pmi-row .field {
-    max-width: 200px;
-}
-
-.hint {
-    font-size: 0.6875rem;
-    color: var(--text-3);
-    margin-top: 0.4rem;
-    line-height: 1.45;
-}
-
-/* Term cards */
-.terms-list {
-    margin-bottom: 0.375rem;
-}
-
-.term-card {
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0.75rem 0.9rem;
-    margin-bottom: 0.375rem;
-    background: var(--surface);
-}
-
-.term-card-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.5rem;
-}
-
-.term-card-header h3 {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--text-2);
-}
-
-.remove-term {
-    background: none;
-    border: none;
-    color: var(--text-3);
-    font-size: 0.875rem;
-    cursor: pointer;
-    padding: 0 0.2rem;
-    line-height: 1;
-    transition: color 0.1s;
-}
-
-.remove-term:hover {
-    color: #c0392b;
-}
-
-.term-fields {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    gap: 0.5rem;
-}
-
-.term-fields .field {
-    min-width: 0;
-}
-
-.btn-link {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0.4rem 0.8rem;
-    color: var(--text-2);
-    cursor: pointer;
-    font-size: 0.6875rem;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    width: 100%;
-    transition: all 0.1s;
-}
-
-.btn-link:hover {
-    border-color: var(--text);
-    color: var(--text);
-}
-
-/* Results */
-.results-section {
-    display: none;
-}
-
-.results-section.visible {
+.terms-section label {
     display: block;
-}
-
-.result-summary {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    gap: 0.375rem;
-    margin-bottom: 1.25rem;
-}
-
-.summary-card {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0.75rem 0.9rem;
-    text-align: left;
-}
-
-.summary-card .label {
-    font-size: 0.625rem;
+    font-size: 0.85rem;
     font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--text-3);
-    margin-bottom: 0.2rem;
-}
-
-.summary-card .value {
-    font-size: 1.125rem;
-    font-weight: 600;
-    font-family: var(--mono);
-    letter-spacing: -0.02em;
-    color: var(--text);
-}
-
-.summary-card.accent {
-    background: var(--accent);
-    border-color: var(--accent);
-    color: #fff;
-}
-
-.summary-card.accent .label {
-    color: rgba(255,255,255,0.55);
-}
-
-.summary-card.accent .value {
-    color: #fff;
-}
-
-.biweekly-compare {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0.65rem 0.9rem;
-    margin-bottom: 1.25rem;
-    font-size: 0.8125rem;
-    color: var(--text-2);
-    line-height: 1.5;
-}
-
-.biweekly-compare strong {
-    color: var(--text);
-    font-weight: 600;
-}
-
-.term-result {
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0.65rem 0.9rem;
-    margin-bottom: 0.375rem;
-    background: var(--surface);
-}
-
-.term-result h4 {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-    color: var(--text-2);
     margin-bottom: 0.4rem;
 }
 
-.term-result-grid {
+.term-toggles {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+}
+
+.term-toggle {
+    padding: 0.35rem 0.9rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #fff;
+    cursor: pointer;
+    font-size: 0.85rem;
+    transition: all 0.15s;
+}
+
+.term-toggle:hover {
+    border-color: #999;
+}
+
+.term-toggle.active {
+    background: #222;
+    color: #fff;
+    border-color: #222;
+}
+
+/* Results */
+.results {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.result-card {
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    padding: 0.9rem 1rem;
+}
+
+.result-card h3 {
+    font-size: 0.95rem;
+    margin-bottom: 0.4rem;
+    color: #555;
+}
+
+.result-card .monthly {
+    font-size: 1.5rem;
+    font-weight: 700;
+}
+
+.result-card .monthly span {
+    font-size: 0.85rem;
+    font-weight: 400;
+    color: #888;
+}
+
+.result-details {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
-    gap: 0.3rem 0.75rem;
-    font-size: 0.8125rem;
+    gap: 0.4rem;
+    margin-top: 0.5rem;
+    font-size: 0.82rem;
+    color: #555;
 }
 
-.term-result-grid dt {
-    color: var(--text-3);
-    font-size: 0.6875rem;
-    font-weight: 500;
-    letter-spacing: 0.02em;
+.result-details dt {
+    color: #999;
 }
 
-.term-result-grid dd {
-    font-weight: 500;
-    font-family: var(--mono);
-    font-size: 0.8125rem;
-    letter-spacing: -0.01em;
+.result-details dd {
+    font-weight: 600;
     margin-left: 0;
-    color: var(--text);
 }
 
-/* Charts */
+/* Chart */
 .chart-section {
-    display: none;
+    margin-top: 2rem;
 }
 
-.chart-section.visible {
-    display: block;
+.chart-section h2 {
+    font-size: 1rem;
+    margin-bottom: 0.75rem;
 }
 
 canvas {
@@ -529,111 +177,12 @@ canvas {
     height: 280px;
 }
 
-/* Schedule toggle */
-.schedule-toggle {
-    display: inline-flex;
-    gap: 0;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    overflow: hidden;
-}
-
-.toggle-btn {
-    border: none;
-    background: var(--surface);
-    padding: 0.2rem 0.6rem;
-    font-size: 0.625rem;
-    font-weight: 600;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    cursor: pointer;
-    color: var(--text-2);
-    transition: all 0.1s;
-}
-
-.toggle-btn.active {
-    background: var(--accent);
-    color: #fff;
-}
-
-/* Amortization table */
-.table-wrap {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-}
-
-#schedule-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 0.75rem;
-    font-family: var(--mono);
-}
-
-#schedule-table th {
-    background: var(--accent-soft);
-    text-align: right;
-    padding: 0.4rem 0.6rem;
-    border-bottom: 1px solid var(--border);
-    font-weight: 600;
-    font-size: 0.625rem;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    color: var(--text-2);
-    white-space: nowrap;
-    position: sticky;
-    top: 0;
-}
-
-#schedule-table th:first-child {
-    text-align: left;
-}
-
-#schedule-table td {
-    text-align: right;
-    padding: 0.35rem 0.6rem;
-    border-bottom: 1px solid var(--border);
-    white-space: nowrap;
-    color: var(--text);
-}
-
-#schedule-table td:first-child {
-    text-align: left;
-    color: var(--text-2);
-}
-
-#schedule-table tbody tr.term-boundary td {
-    border-top: 1px solid var(--text);
-}
-
-/* Footer */
-.tool-footer {
-    margin-top: 3rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--border);
-    font-size: 0.6875rem;
-    line-height: 1.55;
-    color: var(--text-3);
-}
-
 /* Responsive */
 @media (max-width: 500px) {
-    body {
-        padding: 1.25rem 0.75rem 3rem;
+    .input-section {
+        grid-template-columns: 1fr;
     }
-
-    .hook-line {
-        font-size: 1.2rem;
-    }
-
-    .term-fields {
-        grid-template-columns: 1fr 1fr;
-    }
-    .result-summary {
-        grid-template-columns: 1fr 1fr;
-    }
-    .term-result-grid {
+    .result-details {
         grid-template-columns: 1fr 1fr;
     }
 }

--- a/static/tools/multi-term-mortgage-calculator/style.css
+++ b/static/tools/multi-term-mortgage-calculator/style.css
@@ -16,6 +16,52 @@
     --accent-soft: #f3f3f3;
     --radius: 2px;
     --mono: "SF Mono", "Roboto Mono", "Menlo", monospace;
+    --chart-line: #e2e2e2;
+    --chart-text: #888;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #1a1a1a;
+        --surface: #242424;
+        --text: #e0e0e0;
+        --text-2: #aaa;
+        --text-3: #777;
+        --border: #444;
+        --border-focus: #999;
+        --accent: #e0e0e0;
+        --accent-soft: #2d2d2d;
+        --chart-line: #444;
+        --chart-text: #777;
+    }
+}
+
+:root[data-theme="dark"] {
+    --bg: #1a1a1a;
+    --surface: #242424;
+    --text: #e0e0e0;
+    --text-2: #aaa;
+    --text-3: #777;
+    --border: #444;
+    --border-focus: #999;
+    --accent: #e0e0e0;
+    --accent-soft: #2d2d2d;
+    --chart-line: #444;
+    --chart-text: #777;
+}
+
+:root[data-theme="light"] {
+    --bg: #fafafa;
+    --surface: #fff;
+    --text: #111;
+    --text-2: #555;
+    --text-3: #888;
+    --border: #e2e2e2;
+    --border-focus: #111;
+    --accent: #111;
+    --accent-soft: #f3f3f3;
+    --chart-line: #e2e2e2;
+    --chart-text: #888;
 }
 
 body {
@@ -119,6 +165,40 @@ body {
     border-color: var(--text);
     color: var(--text);
 }
+
+/* Header actions */
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+/* Theme toggle */
+.theme-toggle {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.3rem 0.75rem;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-3);
+    cursor: pointer;
+    transition: all 0.1s;
+}
+
+.theme-toggle:hover {
+    border-color: var(--text);
+    color: var(--text);
+}
+
+.theme-icon { display: none; }
+:root[data-theme-mode="auto"], :root:not([data-theme-mode]) { }
+:root[data-theme-mode="auto"] .theme-icon-auto,
+:root:not([data-theme-mode]) .theme-icon-auto { display: inline; }
+:root[data-theme-mode="light"] .theme-icon-light { display: inline; }
+:root[data-theme-mode="dark"] .theme-icon-dark { display: inline; }
 
 /* Country info */
 .country-info {
@@ -583,6 +663,41 @@ select:focus {
 
 .scenario-label.opt { color: #2a7a4a; }
 .scenario-label.pess { color: #a83232; }
+
+:root[data-theme="dark"] .scenario-label.opt { color: #4eca7a; }
+:root[data-theme="dark"] .scenario-label.pess { color: #e85555; }
+
+/* Dark mode: accent card uses inverted scheme */
+:root[data-theme="dark"] .summary-card.accent {
+    background: #e0e0e0;
+    border-color: #e0e0e0;
+    color: #1a1a1a;
+}
+:root[data-theme="dark"] .summary-card.accent .label {
+    color: rgba(26,26,26,0.55);
+}
+:root[data-theme="dark"] .summary-card.accent .value {
+    color: #1a1a1a;
+}
+
+/* Dark mode: active buttons */
+:root[data-theme="dark"] .country-btn.active,
+:root[data-theme="dark"] .toggle-btn.active {
+    background: var(--text);
+    color: var(--bg);
+}
+
+/* Dark mode: select styling */
+:root[data-theme="dark"] select {
+    background: var(--surface);
+    color: var(--text);
+}
+
+/* Dark mode: input autofill */
+:root[data-theme="dark"] .input-wrap input:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 30px #242424 inset;
+    -webkit-text-fill-color: var(--text);
+}
 
 /* Missing years */
 .missing-years {


### PR DESCRIPTION
- Add scenario comparison (optimistic/pessimistic rate offsets)
- Add dark/light theme matching Hugo site mechanism
- Add missing years indicator when terms dont cover amortization
- Fix Canadian bi-weekly/weekly compounding (was 41 bps off)
- Fix undefined `ppy` in US compounding path
- Fix chart colors invisible in dark mode
- Fix select event handling, schedule term boundaries
- Remove dead code, persist schedule mode in localStorage
- Update new-tool template with theme scaffold