### PR TITLE
Fix dark mode inputs, country info, and canvas errors

### DIFF
--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -311,7 +311,8 @@
     function renderCountryInfo() {
         var info = countryInfo[country];
         if (!info) { countryInfoEl.innerHTML = ""; return; }
-        var html = "<ul>";
+        var label = country === "ca" ? "Canada" : "United States";
+        var html = "<span class=\"country-info-label\">" + label + "</span><ul>";
         info.bullets.forEach(function (b) { html += "<li>" + b + "</li>"; });
         html += "</ul>";
         countryInfoEl.innerHTML = html;

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -355,7 +355,7 @@
 
         renderTerms();
         syncLoan();
-        render();
+        try { render(); } catch (e) { /* continue */ }
         renderCountryInfo();
 
         // Auto-expand recurring costs if insurance is relevant
@@ -784,7 +784,7 @@
         if (niceMax === 0) niceMax = 5000;
 
         var barGroupWidth = plotW / tr.length;
-        var barWidth = Math.min(barGroupWidth * 0.55, 60);
+        var barWidth = Math.max(1, Math.min(barGroupWidth * 0.55, 60));
 
         // Grid
         ctx.strokeStyle = cssVar("--chart-line");
@@ -880,7 +880,7 @@
 
         var cx = W * 0.35;
         var cy = H / 2;
-        var radius = Math.min(cx - 20, cy - 15, 100);
+        var radius = Math.max(1, Math.min(cx - 20, cy - 15, 100));
         var startAngle = -Math.PI / 2;
 
         slices.forEach(function (s) {

--- a/static/tools/multi-term-mortgage-calculator/style.css
+++ b/static/tools/multi-term-mortgage-calculator/style.css
@@ -73,6 +73,11 @@ body {
     color: var(--text);
     background: var(--bg);
     -webkit-font-smoothing: antialiased;
+    color-scheme: light;
+}
+
+:root[data-theme="dark"] body {
+    color-scheme: dark;
 }
 
 /* Hook */
@@ -698,13 +703,22 @@ select:focus {
     color: var(--bg);
 }
 
-/* Dark mode: select styling */
+/* Dark mode: inputs */
+:root[data-theme="dark"] .input-wrap input {
+    background: transparent;
+    color: var(--text);
+    caret-color: var(--text);
+}
+
+:root[data-theme="dark"] .input-wrap input[readonly] {
+    color: var(--text-3);
+}
+
 :root[data-theme="dark"] select {
     background: var(--surface);
     color: var(--text);
 }
 
-/* Dark mode: input autofill */
 :root[data-theme="dark"] .input-wrap input:-webkit-autofill {
     -webkit-box-shadow: 0 0 0 30px #242424 inset;
     -webkit-text-fill-color: var(--text);

--- a/static/tools/multi-term-mortgage-calculator/style.css
+++ b/static/tools/multi-term-mortgage-calculator/style.css
@@ -213,6 +213,16 @@ body {
     color: var(--text-2);
 }
 
+.country-info-label {
+    display: inline-block;
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-3);
+    margin-bottom: 0.35rem;
+}
+
 .country-info ul {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
- Fix country info bullets not updating on CA/US switch (uncaught canvas error in render() prevented renderCountryInfo from executing)
- Clamp canvas geometry to min 1 to prevent negative radius arc errors
- Set color-scheme: dark on body so browser form controls render correctly
- Add country name label above feature list for visual clarity