### PR TITLE
Mortgage calculator: audit items #0-#10

### DIFF
--- a/static/tools/multi-term-mortgage-calculator/index.html
+++ b/static/tools/multi-term-mortgage-calculator/index.html
@@ -39,7 +39,7 @@
 
     <div id="country-info" class="country-info"></div>
 
-    <!-- Core inputs: always visible -->
+    <!-- Core inputs -->
     <div class="section">
         <div class="input-row core-row">
             <div class="field">
@@ -63,46 +63,58 @@
                     <input type="number" id="loan-amount" value="400000" min="0" step="1000" readonly>
                 </div>
             </div>
+        </div>
+        <div class="input-row core-row">
             <div class="field">
                 <label for="amortization">Amortization</label>
                 <div class="input-wrap">
-                    <input type="number" id="amortization" value="25" min="1" max="40" step="1">
+                    <input type="number" id="amortization" value="25" min="1" max="30" step="1">
                     <span class="suffix">yr</span>
                 </div>
             </div>
+            <div class="field">
+                <label for="payment-frequency">Payment Frequency</label>
+                <select id="payment-frequency">
+                    <option value="monthly">Monthly</option>
+                    <option value="semimonthly">Semi-monthly</option>
+                    <option value="biweekly">Bi-weekly</option>
+                    <option value="accelerated_biweekly">Accelerated bi-weekly</option>
+                    <option value="weekly">Weekly</option>
+                    <option value="accelerated_weekly">Accelerated weekly</option>
+                </select>
+            </div>
         </div>
+
+        <!-- CMHC display (Canada only) -->
+        <div id="cmhc-row" class="cmhc-row" style="display:none">
+            <div class="cmhc-info">
+                <span id="cmhc-amount" class="cmhc-amount"></span>
+            </div>
+            <div id="cmhc-eligibility" class="cmhc-eligibility" style="display:none">
+                <label class="checkbox-label"><input type="checkbox" id="first-time-buyer"> First-time home buyer</label>
+                <label class="checkbox-label"><input type="checkbox" id="new-build"> New build</label>
+            </div>
+            <div id="cmhc-warnings" class="cmhc-warnings"></div>
+        </div>
+
         <div id="terms-list" class="terms-list"></div>
         <button id="add-term" class="btn-link">+ Add another term</button>
     </div>
 
-    <!-- Expandable: scenarios -->
+    <!-- Scenarios -->
     <div class="section collapsible">
         <button class="section-toggle" id="toggle-scenarios">
             <span class="section-title">Scenarios</span>
             <span class="toggle-arrow" id="arrow-scenarios"></span>
         </button>
         <div class="section-body collapsed" id="body-scenarios">
-            <p class="scenario-hint">Adjust term rates by a fixed offset to model optimistic (rates fall) or pessimistic (rates rise) outcomes.</p>
-            <div class="input-row">
-                <div class="field">
-                    <label for="rate-optimistic">Optimistic</label>
-                    <div class="input-wrap">
-                        <input type="number" id="rate-optimistic" value="-1" min="-10" max="0" step="0.25">
-                        <span class="suffix">%</span>
-                    </div>
-                </div>
-                <div class="field">
-                    <label for="rate-pessimistic">Pessimistic</label>
-                    <div class="input-wrap">
-                        <input type="number" id="rate-pessimistic" value="2" min="0" max="10" step="0.25">
-                        <span class="suffix">%</span>
-                    </div>
-                </div>
-            </div>
+            <div id="scenario-chips" class="scenario-chips"></div>
+            <button id="add-scenario" class="btn-link">+ Add Scenario</button>
+            <div id="scenario-editor" class="scenario-editor"></div>
         </div>
     </div>
 
-    <!-- Expandable: prepayments -->
+    <!-- Prepayments -->
     <div class="section collapsible">
         <button class="section-toggle" id="toggle-prepay">
             <span class="section-title">Prepayments</span>
@@ -135,50 +147,7 @@
         </div>
     </div>
 
-    <!-- Expandable: recurring costs -->
-    <div class="section collapsible">
-        <button class="section-toggle" id="toggle-costs">
-            <span class="section-title">Recurring Costs</span>
-            <span class="toggle-arrow" id="arrow-costs"></span>
-        </button>
-        <div class="section-body collapsed" id="body-costs">
-            <div class="input-row">
-                <div class="field">
-                    <label for="property-tax" id="property-tax-label">Property Tax / Year</label>
-                    <div class="input-wrap">
-                        <span class="prefix">$</span>
-                        <input type="number" id="property-tax" value="3500" min="0" step="100">
-                    </div>
-                </div>
-                <div class="field">
-                    <label for="home-insurance">Home Insurance / Year</label>
-                    <div class="input-wrap">
-                        <span class="prefix">$</span>
-                        <input type="number" id="home-insurance" value="1200" min="0" step="100">
-                    </div>
-                </div>
-                <div class="field">
-                    <label for="hoa" id="hoa-label">HOA / Month</label>
-                    <div class="input-wrap">
-                        <span class="prefix">$</span>
-                        <input type="number" id="hoa" value="0" min="0" step="25">
-                    </div>
-                </div>
-            </div>
-            <div class="pmi-row" id="pmi-row" style="display:none;">
-                <div class="field">
-                    <label for="pmi" id="pmi-label">Mortgage Insurance</label>
-                    <div class="input-wrap">
-                        <input type="number" id="pmi" value="0" min="0" step="0.01">
-                        <span class="suffix">%/yr</span>
-                    </div>
-                </div>
-            </div>
-            <div class="hint" id="pmi-hint"></div>
-        </div>
-    </div>
-
-    <!-- Expandable: start date -->
+    <!-- Start Date -->
     <div class="section collapsible">
         <button class="section-toggle" id="toggle-date">
             <span class="section-title">Start Date</span>
@@ -208,15 +177,37 @@
     <!-- Results -->
     <div id="results" class="section results-section"></div>
 
-    <!-- Charts -->
-    <div id="chart-section" class="section chart-section">
-        <h2 class="section-title">Interest Paid Per Term</h2>
-        <canvas id="interestChart"></canvas>
-    </div>
+    <!-- Savings cards -->
+    <div id="savings-cards" class="section savings-section"></div>
 
-    <div id="pie-section" class="section chart-section">
-        <h2 class="section-title">Total Cost Breakdown</h2>
-        <canvas id="pieChart"></canvas>
+    <!-- Charts -->
+    <div id="charts-container" class="section charts-container" style="display:none">
+        <div class="chart-tabs">
+            <button class="chart-tab active" data-chart="balance">Balance Over Time</button>
+            <button class="chart-tab" data-chart="cumulative">Cumulative Interest</button>
+            <button class="chart-tab" data-chart="payment">Payment Over Time</button>
+            <button class="chart-tab" data-chart="ip">Interest vs Principal</button>
+        </div>
+        <div class="chart-panel visible" id="panel-balance">
+            <canvas id="balanceChart"></canvas>
+        </div>
+        <div class="chart-panel" id="panel-cumulative">
+            <canvas id="cumulativeInterestChart"></canvas>
+        </div>
+        <div class="chart-panel" id="panel-payment">
+            <canvas id="paymentChart"></canvas>
+        </div>
+        <div class="chart-panel" id="panel-ip">
+            <div class="ip-header">
+                <select id="ip-scenario-select"></select>
+            </div>
+            <canvas id="ipSplitChart"></canvas>
+        </div>
+
+        <!-- Interest per term bar chart -->
+        <div class="chart-panel" id="panel-interest-bar">
+            <canvas id="interestBarChart"></canvas>
+        </div>
     </div>
 
     <!-- Amortization schedule -->
@@ -224,7 +215,7 @@
         <h2 class="section-title">
             Amortization Schedule
             <div class="schedule-toggle">
-                <button id="btn-monthly" class="toggle-btn">Monthly</button>
+                <button id="btn-detail" class="toggle-btn">Detail</button>
                 <button id="btn-annual" class="toggle-btn active">Annual</button>
             </div>
         </h2>
@@ -234,6 +225,12 @@
                 <tbody></tbody>
             </table>
         </div>
+    </div>
+
+    <!-- Export/Share -->
+    <div id="export-section" class="section export-section" style="display:none">
+        <button id="btn-share" class="export-btn">Copy shareable link</button>
+        <button id="btn-csv" class="export-btn">Export CSV</button>
     </div>
 
     <footer class="tool-footer">
@@ -264,6 +261,8 @@
             });
         })();
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3/dist/chartjs-plugin-annotation.min.js"></script>
     <script src="./script.js"></script>
 </body>
 </html>

--- a/static/tools/multi-term-mortgage-calculator/index.html
+++ b/static/tools/multi-term-mortgage-calculator/index.html
@@ -187,6 +187,7 @@
             <button class="chart-tab" data-chart="cumulative">Cumulative Interest</button>
             <button class="chart-tab" data-chart="payment">Payment Over Time</button>
             <button class="chart-tab" data-chart="ip">Interest vs Principal</button>
+            <button class="chart-tab" data-chart="interest-bar">Interest Per Term</button>
         </div>
         <div class="chart-panel visible" id="panel-balance">
             <canvas id="balanceChart"></canvas>
@@ -206,6 +207,7 @@
 
         <!-- Interest per term bar chart -->
         <div class="chart-panel" id="panel-interest-bar">
+            <h3 class="section-title">Interest Paid Per Term</h3>
             <canvas id="interestBarChart"></canvas>
         </div>
     </div>

--- a/static/tools/multi-term-mortgage-calculator/index.html
+++ b/static/tools/multi-term-mortgage-calculator/index.html
@@ -231,6 +231,7 @@
     <div id="export-section" class="section export-section" style="display:none">
         <button id="btn-share" class="export-btn">Copy shareable link</button>
         <button id="btn-csv" class="export-btn">Export CSV</button>
+        <button id="btn-png" class="export-btn">Export chart as PNG</button>
     </div>
 
     <footer class="tool-footer">

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -1,52 +1,285 @@
 (function () {
-    // --- DOM refs ---
-    var homeValueInput = document.getElementById("home-value");
-    var downPaymentInput = document.getElementById("down-payment");
-    var loanAmountInput = document.getElementById("loan-amount");
-    var downPctEl = document.getElementById("down-pct");
-    var amortInput = document.getElementById("amortization");
-    var paymentIncreaseInput = document.getElementById("payment-increase");
-    var lumpSumAnnualInput = document.getElementById("lump-sum-annual");
-    var lumpSumTermInput = document.getElementById("lump-sum-term");
-    var propertyTaxInput = document.getElementById("property-tax");
-    var homeInsuranceInput = document.getElementById("home-insurance");
-    var hoaInput = document.getElementById("hoa");
-    var pmiInput = document.getElementById("pmi");
-    var pmiRow = document.getElementById("pmi-row");
-    var pmiHint = document.getElementById("pmi-hint");
-    var pmiLabel = document.getElementById("pmi-label");
-    var hoaLabel = document.getElementById("hoa-label");
-    var propertyTaxLabel = document.getElementById("property-tax-label");
-    var startMonthInput = document.getElementById("start-month");
-    var startYearInput = document.getElementById("start-year");
-    var termsList = document.getElementById("terms-list");
-    var addTermBtn = document.getElementById("add-term");
-    var resultsEl = document.getElementById("results");
-    var chartSection = document.getElementById("chart-section");
-    var pieSection = document.getElementById("pie-section");
-    var scheduleSection = document.getElementById("schedule-section");
-    var scheduleTableBody = document.querySelector("#schedule-table tbody");
-    var scheduleTableHead = document.querySelector("#schedule-table thead");
-    var btnMonthly = document.getElementById("btn-monthly");
-    var btnAnnual = document.getElementById("btn-annual");
-    var btnCA = document.getElementById("btn-ca");
-    var btnUS = document.getElementById("btn-us");
-    var countryInfoEl = document.getElementById("country-info");
-    var btnClear = document.getElementById("btn-clear");
-    var hookLoan = document.getElementById("hook-loan");
-    var hookInterest = document.getElementById("hook-interest");
-    var rateOptimisticInput = document.getElementById("rate-optimistic");
-    var ratePessimisticInput = document.getElementById("rate-pessimistic");
+    // ===== CONSTANTS =====
+    var LS_KEY = "mortgage-calc-v2";
+    var LS_COLLAPSED_KEY = "mortgage-calc-v2-collapsed";
+    var monthNames = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
 
-    // Collapsible sections
-    var collapsibles = {
-        prepay: { toggle: document.getElementById("toggle-prepay"), body: document.getElementById("body-prepay"), arrow: document.getElementById("arrow-prepay") },
-        costs:  { toggle: document.getElementById("toggle-costs"),  body: document.getElementById("body-costs"),  arrow: document.getElementById("arrow-costs") },
-        scenarios: { toggle: document.getElementById("toggle-scenarios"), body: document.getElementById("body-scenarios"), arrow: document.getElementById("arrow-scenarios") },
-        date:   { toggle: document.getElementById("toggle-date"),   body: document.getElementById("body-date"),   arrow: document.getElementById("arrow-date") },
+    var countryInfo = {
+        ca: {
+            bullets: [
+                "<strong>Semi-annual compounding.</strong> Interest compounds twice a year, so the effective monthly rate is lower than rate/12.",
+                "<strong>CMHC default insurance</strong> required when down payment is under 20%. Premium is a one-time cost added to the mortgage principal.",
+                "<strong>Term vs amortization.</strong> Typical terms are 1-5 years at a fixed rate; the amortization is 25-30 years. Rate renegotiated at each renewal.",
+                "<strong>Prepayment limits.</strong> Most lenders allow 10-20% lump sum per year and payment increases up to double. Penalties apply beyond that.",
+            ],
+        },
+        us: {
+            bullets: [
+                "<strong>Monthly compounding.</strong> Interest is calculated at rate/12 each month. The quoted rate equals the effective rate.",
+                "<strong>30-year fixed</strong> is the most common mortgage. You lock the rate for the entire loan. No renewals.",
+                "<strong>No CMHC.</strong> PMI is out of scope for this calculator.",
+            ],
+        },
     };
 
-    // Collapsible toggle handlers
+    var countryConfig = {
+        ca: {
+            defaultAmort: 25,
+            maxAmort: 30,
+            defaultTerms: [
+                { years: 5, rate: 4.99 },
+                { years: 5, rate: 4.49 },
+                { years: 5, rate: 4.19 },
+                { years: 5, rate: 3.99 },
+                { years: 5, rate: 3.79 },
+            ],
+            compounding: "semi-annual",
+            newTermDuration: 5,
+        },
+        us: {
+            defaultAmort: 30,
+            maxAmort: 40,
+            defaultTerms: [
+                { years: 30, rate: 6.5 },
+            ],
+            compounding: "monthly",
+            newTermDuration: 5,
+        },
+    };
+
+    var frequencyConfig = {
+        monthly:              { ppy: 12, label: "Monthly", suffix: "/mo" },
+        semimonthly:          { ppy: 24, label: "Semi-monthly", suffix: "/semi-mo" },
+        biweekly:             { ppy: 26, label: "Bi-weekly", suffix: "/bi-wk" },
+        accelerated_biweekly: { ppy: 26, label: "Accelerated bi-weekly", suffix: "/bi-wk" },
+        weekly:               { ppy: 52, label: "Weekly", suffix: "/wk" },
+        accelerated_weekly:   { ppy: 52, label: "Accelerated weekly", suffix: "/wk" },
+    };
+
+    var scenarioPresetColors = ["#2ecc71", "#e74c3c", "#f39c12", "#9b59b6", "#1abc9c"];
+    var baseColor = "#4f86c6";
+    var termColorsLight = ["#111", "#4a4a4a", "#7a7a7a", "#a5a5a5", "#c5c5c5", "#333", "#5a5a5a", "#8a8a8a"];
+    var termColorsDark  = ["#e0e0e0", "#b0b0b0", "#888888", "#666666", "#444444", "#ccc", "#999", "#777"];
+
+    // ===== STATE =====
+    var country = "ca";
+    var terms = [];
+    var scenarios = [];
+    var paymentFrequency = "monthly";
+    var firstTimeBuyer = false;
+    var newBuild = false;
+    var scheduleMode = "annual";
+    var lastSimResults = null; // { base: sim, scenarios: { id: sim } }
+    var chartInstances = {};
+    var editingScenarioId = null;
+
+    // ===== DOM HELPERS =====
+    function $(id) { return document.getElementById(id); }
+
+    // ===== MATH HELPERS =====
+
+    function isDark() {
+        return getComputedStyle(document.documentElement).getPropertyValue("--bg").trim() !== "#fafafa";
+    }
+
+    function getTermColors() {
+        return isDark() ? termColorsDark : termColorsLight;
+    }
+
+    function effectivePeriodRate(annualRate, frequency, compounding) {
+        var ppy = frequencyConfig[frequency].ppy;
+        if (compounding === "semi-annual") {
+            var semiRate = annualRate / 100 / 2;
+            return Math.pow(1 + semiRate, 2 / ppy) - 1;
+        }
+        return annualRate / 100 / ppy;
+    }
+
+    function calcMonthlyPayment(principal, annualRate, amortYears, compounding) {
+        var r = effectivePeriodRate(annualRate, "monthly", compounding);
+        var n = amortYears * 12;
+        if (principal <= 0 || n <= 0) return 0;
+        if (r === 0) return principal / n;
+        return principal * (r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1);
+    }
+
+    function calcPeriodicPayment(principal, annualRate, remainingAmortYears, frequency, compounding) {
+        var monthlyPmt = calcMonthlyPayment(principal, annualRate, remainingAmortYears, compounding);
+        switch (frequency) {
+            case "monthly": return monthlyPmt;
+            case "semimonthly": return monthlyPmt / 2;
+            case "biweekly": return (monthlyPmt * 12) / 26;
+            case "accelerated_biweekly": return monthlyPmt / 2;
+            case "weekly": return (monthlyPmt * 12) / 52;
+            case "accelerated_weekly": return monthlyPmt / 4;
+            default: return monthlyPmt;
+        }
+    }
+
+    // ===== CMHC =====
+
+    function cmhcRate(downPct) {
+        if (downPct < 5) return 4.0;
+        if (downPct < 10) return 4.0;
+        if (downPct < 15) return 3.1;
+        if (downPct < 20) return 2.8;
+        return 0;
+    }
+
+    function calcCmhcPremium(loanAmount, downPct) {
+        if (downPct >= 20) return 0;
+        return loanAmount * cmhcRate(downPct) / 100;
+    }
+
+    function getCmhcWarnings(homeValue, downPct, amortYears) {
+        var warnings = [];
+        if (downPct >= 20) return warnings;
+        if (homeValue >= 1500000) {
+            warnings.push("CMHC not available above $1.5M. 20% minimum down payment required.");
+        }
+        if (amortYears > 25 && !firstTimeBuyer && !newBuild) {
+            warnings.push("CMHC requires maximum 25-year amortization. Check \"First-time buyer\" or \"New build\" for 30-year eligibility.");
+        }
+        if (amortYears > 30) {
+            warnings.push("CMHC not available with amortization over 30 years.");
+        }
+        return warnings;
+    }
+
+    // ===== FORMATTING =====
+
+    function addCommas(n) {
+        var parts = n.toString().split(".");
+        parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+        return parts.join(".");
+    }
+
+    function fmt(val) {
+        return "$" + addCommas(Math.round(val));
+    }
+
+    function fmtFull(val) {
+        var sign = val < 0 ? "-" : "";
+        var abs = Math.abs(val);
+        var rounded = Math.round(abs * 100) / 100;
+        var parts = rounded.toFixed(2).split(".");
+        return sign + "$" + addCommas(parseInt(parts[0])) + "." + parts[1];
+    }
+
+    function fmtPct(val) {
+        return val.toFixed(1) + "%";
+    }
+
+    function cssVar(name) {
+        return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    }
+
+    function freqSuffix() {
+        return frequencyConfig[paymentFrequency] ? frequencyConfig[paymentFrequency].suffix : "/mo";
+    }
+
+    function freqLabel() {
+        return frequencyConfig[paymentFrequency] ? frequencyConfig[paymentFrequency].label : "Monthly";
+    }
+
+    // ===== LOCAL STORAGE =====
+
+    function saveState() {
+        try {
+            var state = {
+                v: 2,
+                country: country,
+                homeValue: $("home-value").value,
+                downPayment: $("down-payment").value,
+                amortization: $("amortization").value,
+                paymentIncrease: $("payment-increase").value,
+                lumpSumAnnual: $("lump-sum-annual").value,
+                lumpSumTerm: $("lump-sum-term").value,
+                startMonth: $("start-month").value,
+                startYear: $("start-year").value,
+                scheduleMode: scheduleMode,
+                paymentFrequency: paymentFrequency,
+                firstTimeBuyer: firstTimeBuyer,
+                newBuild: newBuild,
+                scenarios: scenarios,
+                terms: terms,
+            };
+            localStorage.setItem(LS_KEY, JSON.stringify(state));
+        } catch (e) {}
+    }
+
+    function loadState() {
+        try {
+            var raw = localStorage.getItem(LS_KEY);
+            if (!raw) return null;
+            return JSON.parse(raw);
+        } catch (e) { return null; }
+    }
+
+    function migrateState(old) {
+        if (!old) return null;
+        if (old.v === 2) return old;
+        var s = {
+            v: 2,
+            country: old.country || "ca",
+            homeValue: old.homeValue || "500000",
+            downPayment: old.downPayment || "100000",
+            amortization: old.amortization || "25",
+            paymentIncrease: old.paymentIncrease || "0",
+            lumpSumAnnual: old.lumpSumAnnual || "0",
+            lumpSumTerm: old.lumpSumTerm || "0",
+            startMonth: old.startMonth || "5",
+            startYear: old.startYear || "2026",
+            scheduleMode: old.scheduleMode || "annual",
+            paymentFrequency: "monthly",
+            firstTimeBuyer: false,
+            newBuild: false,
+            terms: (old.terms || []).map(function (t) { return { years: t.years, rate: t.rate }; }),
+            scenarios: [{ id: "base", label: "Base", locked: true, color: baseColor, visible: true }],
+        };
+        var optOffset = parseFloat(old.rateOptimistic) || 0;
+        var pessOffset = parseFloat(old.ratePessimistic) || 0;
+        if (optOffset !== 0) {
+            s.scenarios.push({ id: "s1", label: "Optimistic", mode: "offset", offset: optOffset, color: "#2ecc71", visible: true });
+        }
+        if (pessOffset !== 0) {
+            s.scenarios.push({ id: "s2", label: "Pessimistic", mode: "offset", offset: pessOffset, color: "#e74c3c", visible: true });
+        }
+        return s;
+    }
+
+    function clearState() {
+        try { localStorage.removeItem(LS_KEY); localStorage.removeItem(LS_COLLAPSED_KEY); } catch (e) {}
+    }
+
+    function applyState(s) {
+        if (!s) return false;
+        country = s.country || "ca";
+        if (s.terms && s.terms.length > 0) terms = s.terms;
+        if (s.scenarios && s.scenarios.length > 0) scenarios = s.scenarios;
+        if (s.paymentFrequency) paymentFrequency = s.paymentFrequency;
+        if (s.firstTimeBuyer !== undefined) firstTimeBuyer = s.firstTimeBuyer;
+        if (s.newBuild !== undefined) newBuild = s.newBuild;
+        if (s.scheduleMode) scheduleMode = s.scheduleMode;
+        $("home-value").value = s.homeValue || "500000";
+        $("down-payment").value = s.downPayment || "100000";
+        $("amortization").value = s.amortization || "25";
+        $("payment-increase").value = s.paymentIncrease || "0";
+        $("lump-sum-annual").value = s.lumpSumAnnual || "0";
+        $("lump-sum-term").value = s.lumpSumTerm || "0";
+        $("start-month").value = s.startMonth || "5";
+        $("start-year").value = s.startYear || "2026";
+        return true;
+    }
+
+    // ===== COLLAPSIBLES =====
+
+    var collapsibles = {
+        scenarios: { toggle: $("toggle-scenarios"), body: $("body-scenarios"), arrow: $("arrow-scenarios") },
+        prepay:    { toggle: $("toggle-prepay"),    body: $("body-prepay"),    arrow: $("arrow-prepay") },
+        date:      { toggle: $("toggle-date"),      body: $("body-date"),      arrow: $("arrow-date") },
+    };
+
     Object.keys(collapsibles).forEach(function (key) {
         var c = collapsibles[key];
         c.toggle.addEventListener("click", function () {
@@ -63,13 +296,13 @@
             Object.keys(collapsibles).forEach(function (key) {
                 state[key] = collapsibles[key].body.classList.contains("collapsed");
             });
-            localStorage.setItem(LS_KEY + "-collapsed", JSON.stringify(state));
+            localStorage.setItem(LS_COLLAPSED_KEY, JSON.stringify(state));
         } catch (e) {}
     }
 
     function loadCollapsedState() {
         try {
-            var raw = localStorage.getItem(LS_KEY + "-collapsed");
+            var raw = localStorage.getItem(LS_COLLAPSED_KEY);
             if (!raw) return;
             var state = JSON.parse(raw);
             Object.keys(state).forEach(function (key) {
@@ -81,352 +314,78 @@
         } catch (e) {}
     }
 
-    var countryInfo = {
-        ca: {
-            bullets: [
-                "<strong>Semi-annual compounding.</strong> Interest compounds twice a year, so the effective monthly rate is lower than rate/12.",
-                "<strong>CMHC default insurance</strong> required when down payment is under 20%. Premium is a one-time cost (0.6% to 4% of loan) added to the mortgage.",
-                "<strong>Term vs amortization.</strong> Typical terms are 1-5 years at a fixed rate; the amortization is 25-30 years. Rate renegotiated at each renewal.",
-                "<strong>Prepayment limits.</strong> Most lenders allow 10-20% lump sum per year and payment increases up to double. Penalties apply beyond that.",
-            ],
-        },
-        us: {
-            bullets: [
-                "<strong>Monthly compounding.</strong> Interest is calculated at rate/12 each month. The quoted rate equals the effective rate.",
-                "<strong>PMI</strong> required when down payment is under 20%. Ongoing monthly cost that cancels automatically at 78-80% LTV.",
-                "<strong>30-year fixed</strong> is the most common mortgage. You lock the rate for the entire loan. No renewals.",
-                "<strong>HOA</strong> (Homeowners Association) fees are common for condos and planned communities. Typically paid monthly.",
-            ],
-        },
-    };
-
-    var termColorsLight = ["#111", "#4a4a4a", "#7a7a7a", "#a5a5a5", "#c5c5c5", "#333", "#5a5a5a", "#8a8a8a"];
-    var termColorsDark = ["#e0e0e0", "#b0b0b0", "#888888", "#666666", "#444444", "#ccc", "#999", "#777"];
-    var pieColorsLight = ["#111", "#4a4a4a", "#7a7a7a", "#a5a5a5", "#c5c5c5", "#ddd"];
-    var pieColorsDark = ["#e0e0e0", "#b0b0b0", "#888888", "#666666", "#444444", "#333"];
-
-    function termColors() {
-        var dark = getComputedStyle(document.documentElement).getPropertyValue('--bg').trim() !== '#fafafa';
-        return dark ? termColorsDark : termColorsLight;
-    }
-
-    function pieColors() {
-        var dark = getComputedStyle(document.documentElement).getPropertyValue('--bg').trim() !== '#fafafa';
-        return dark ? pieColorsDark : pieColorsLight;
-    }
-    var monthNames = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
-
-    // --- Country presets ---
-    var countryConfig = {
-        ca: {
-            defaultAmort: 25,
-            maxAmort: 30,
-            defaultTerms: [
-                { years: 5, rate: 4.99, schedule: "monthly" },
-                { years: 5, rate: 4.49, schedule: "monthly" },
-                { years: 5, rate: 4.19, schedule: "monthly" },
-                { years: 5, rate: 3.99, schedule: "monthly" },
-                { years: 5, rate: 3.79, schedule: "monthly" },
-            ],
-            compounding: "semi-annual", // Canadian fixed mortgages compound semi-annually
-            insuranceLabel: "Default Insurance (CMHC)",
-            hoaLabel: "Condo Fees / Month",
-            taxLabel: "Property Tax / Year",
-            newTermDuration: 5,
-            pmiEstimate: function (downPct) {
-                // CMHC rates: 4% for 5-9.99%, 3.1% for 10-14.99%, 2.4% for 15-19.99%
-                if (downPct < 5) return 4.0;
-                if (downPct < 10) return 3.1;
-                if (downPct < 15) return 2.4;
-                if (downPct < 20) return 1.8;
-                return 0;
-            },
-            pmiIsUpfront: true, // CMHC is a one-time premium added to loan
-        },
-        us: {
-            defaultAmort: 30,
-            maxAmort: 40,
-            defaultTerms: [
-                { years: 30, rate: 6.5, schedule: "monthly" },
-            ],
-            compounding: "monthly",
-            insuranceLabel: "PMI",
-            hoaLabel: "HOA / Month",
-            taxLabel: "Property Tax / Year",
-            newTermDuration: 5,
-            pmiEstimate: function (downPct) {
-                if (downPct < 5) return 1.5;
-                if (downPct < 10) return 1.0;
-                if (downPct < 15) return 0.6;
-                if (downPct < 20) return 0.3;
-                return 0;
-            },
-            pmiIsUpfront: false, // PMI is ongoing monthly
-        },
-    };
-
-    var country = "ca";
-    var terms = [];
-    var scheduleMode = "annual";
-    var lastSimResult = null;
-    var LS_KEY = "mortgage-calc-v1";
-
-    // --- Helpers ---
-
-    function schedulePaymentsPerYear(schedule) {
-        if (schedule === "biweekly") return 26;
-        if (schedule === "weekly") return 52;
-        return 12;
-    }
-
-    function scheduleLabel(schedule) {
-        if (schedule === "biweekly") return "bi-weekly";
-        if (schedule === "weekly") return "weekly";
-        return "monthly";
-    }
-
-    function calcBasePayment(principal, annualRate, amortYears, schedule, compounding) {
-        var ppy = schedulePaymentsPerYear(schedule);
-        var n = amortYears * ppy;
-        if (principal <= 0 || n <= 0) return 0;
-
-        var r = effectivePeriodRate(annualRate, schedule, compounding);
-
-        if (r === 0) return principal / n;
-        return principal * (r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1);
-    }
-
-    function effectivePeriodRate(annualRate, schedule, compounding) {
-        if (compounding === "semi-annual") {
-            // Canadian: semi-annual compounding
-            // Semi rate = annualRate/2, then derive period rate from half-year
-            // Monthly: 6 periods per half-year → (1+semiRate)^(1/6) - 1
-            // Bi-weekly: 13 periods per half-year → (1+semiRate)^(1/13) - 1
-            // Weekly: 26 periods per half-year → (1+semiRate)^(1/26) - 1
-            var semiRate = annualRate / 100 / 2;
-            var periodsPerHalfYear = schedule === "monthly" ? 6 : schedule === "biweekly" ? 13 : 26;
-            return Math.pow(1 + semiRate, 1 / periodsPerHalfYear) - 1;
-        }
-        // US: monthly compounding
-        return annualRate / 100 / schedulePaymentsPerYear(schedule);
-    }
-
-    function addCommas(n) {
-        var parts = n.toString().split(".");
-        parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-        return parts.join(".");
-    }
-
-    function fmt(val) {
-        return "$" + addCommas(Math.round(val));
-    }
-
-    function fmtFull(val) {
-        var rounded = Math.round(val * 100) / 100;
-        var parts = rounded.toFixed(2).split(".");
-        return "$" + addCommas(parseInt(parts[0])) + "." + parts[1];
-    }
-
-    function fmtPct(val) {
-        return val.toFixed(1) + "%";
-    }
-
-    // --- Local storage ---
-
-    function saveState() {
-        try {
-            var state = {
-                country: country,
-                homeValue: homeValueInput.value,
-                downPayment: downPaymentInput.value,
-                amortization: amortInput.value,
-                paymentIncrease: paymentIncreaseInput.value,
-                lumpSumAnnual: lumpSumAnnualInput.value,
-                lumpSumTerm: lumpSumTermInput.value,
-                propertyTax: propertyTaxInput.value,
-                homeInsurance: homeInsuranceInput.value,
-                hoa: hoaInput.value,
-                pmi: pmiInput.value,
-                startMonth: startMonthInput.value,
-                startYear: startYearInput.value,
-                scheduleMode: scheduleMode,
-                rateOptimistic: rateOptimisticInput.value,
-                ratePessimistic: ratePessimisticInput.value,
-                terms: terms,
-            };
-            localStorage.setItem(LS_KEY, JSON.stringify(state));
-        } catch (e) { /* storage full or unavailable */ }
-    }
-
-    function loadState() {
-        try {
-            var raw = localStorage.getItem(LS_KEY);
-            if (!raw) return null;
-            return JSON.parse(raw);
-        } catch (e) { return null; }
-    }
-
-    function clearState() {
-        try { localStorage.removeItem(LS_KEY); } catch (e) {}
-    }
-
-    function applyState(s) {
-        if (!s) return false;
-        if (s.country && countryConfig[s.country]) {
-            country = s.country;
-            btnCA.classList.toggle("active", country === "ca");
-            btnUS.classList.toggle("active", country === "us");
-            var cfg = countryConfig[country];
-            pmiLabel.textContent = cfg.insuranceLabel;
-            hoaLabel.textContent = cfg.hoaLabel;
-            propertyTaxLabel.textContent = cfg.taxLabel;
-            amortInput.max = cfg.maxAmort;
-        }
-        if (s.homeValue !== undefined) homeValueInput.value = s.homeValue;
-        if (s.downPayment !== undefined) downPaymentInput.value = s.downPayment;
-        if (s.amortization !== undefined) amortInput.value = s.amortization;
-        if (s.paymentIncrease !== undefined) paymentIncreaseInput.value = s.paymentIncrease;
-        if (s.lumpSumAnnual !== undefined) lumpSumAnnualInput.value = s.lumpSumAnnual;
-        if (s.lumpSumTerm !== undefined) lumpSumTermInput.value = s.lumpSumTerm;
-        if (s.propertyTax !== undefined) propertyTaxInput.value = s.propertyTax;
-        if (s.homeInsurance !== undefined) homeInsuranceInput.value = s.homeInsurance;
-        if (s.hoa !== undefined) hoaInput.value = s.hoa;
-        if (s.pmi !== undefined) pmiInput.value = s.pmi;
-        if (s.startMonth !== undefined) startMonthInput.value = s.startMonth;
-        if (s.startYear !== undefined) startYearInput.value = s.startYear;
-        if (s.scheduleMode !== undefined) {
-            scheduleMode = s.scheduleMode;
-            btnMonthly.classList.toggle("active", scheduleMode === "monthly");
-            btnAnnual.classList.toggle("active", scheduleMode === "annual");
-        }
-        if (s.rateOptimistic !== undefined) rateOptimisticInput.value = s.rateOptimistic;
-        if (s.ratePessimistic !== undefined) ratePessimisticInput.value = s.ratePessimistic;
-        if (s.terms && Array.isArray(s.terms) && s.terms.length > 0) {
-            terms = s.terms;
-        }
-        renderCountryInfo();
-        return true;
-    }
+    // ===== COUNTRY SWITCHING =====
 
     function renderCountryInfo() {
         var info = countryInfo[country];
-        if (!info) { countryInfoEl.innerHTML = ""; return; }
+        if (!info) { $("country-info").innerHTML = ""; return; }
         var label = country === "ca" ? "Canada" : "United States";
         var html = "<span class=\"country-info-label\">" + label + "</span><ul>";
         info.bullets.forEach(function (b) { html += "<li>" + b + "</li>"; });
         html += "</ul>";
-        countryInfoEl.innerHTML = html;
+        $("country-info").innerHTML = html;
     }
-
-    // --- Country switching ---
 
     function switchCountry(c) {
         country = c;
-        btnCA.classList.toggle("active", c === "ca");
-        btnUS.classList.toggle("active", c === "us");
-
+        $("btn-ca").classList.toggle("active", c === "ca");
+        $("btn-us").classList.toggle("active", c === "us");
         var cfg = countryConfig[country];
-
-        // Update labels
-        pmiLabel.textContent = cfg.insuranceLabel;
-        hoaLabel.textContent = cfg.hoaLabel;
-        propertyTaxLabel.textContent = cfg.taxLabel;
-
-        // Update amortization
-        amortInput.max = cfg.maxAmort;
-        amortInput.value = cfg.defaultAmort;
-
-        // Reset terms to country defaults
-        terms = cfg.defaultTerms.map(function (t) { return { years: t.years, rate: t.rate, schedule: t.schedule }; });
-
-        // Reset PMI — syncLoan will re-estimate based on new country
-        pmiInput.value = 0;
-
-        // Set country-specific defaults for recurring costs
-        if (c === "ca") {
-            propertyTaxInput.value = 3500;
-            homeInsuranceInput.value = 1200;
-            hoaInput.value = 0;
-        } else {
-            propertyTaxInput.value = 5500;
-            homeInsuranceInput.value = 2000;
-            hoaInput.value = 0;
-        }
-
+        $("amortization").max = cfg.maxAmort;
+        $("amortization").value = cfg.defaultAmort;
+        terms = cfg.defaultTerms.map(function (t) { return { years: t.years, rate: t.rate }; });
+        paymentFrequency = "monthly";
+        $("payment-frequency").value = "monthly";
+        firstTimeBuyer = false;
+        newBuild = false;
+        $("first-time-buyer").checked = false;
+        $("new-build").checked = false;
         renderTerms();
         syncLoan();
-        try { render(); } catch (e) { /* continue */ }
         renderCountryInfo();
-
-        // Auto-expand recurring costs if insurance is relevant
-        var downPct = (parseFloat(homeValueInput.value) || 0) > 0
-            ? (parseFloat(downPaymentInput.value) || 0) / (parseFloat(homeValueInput.value) || 0) * 100
-            : 100;
-        if (downPct < 20) {
-            collapsibles.costs.body.classList.remove("collapsed");
-            collapsibles.costs.arrow.classList.add("open");
-        }
-
+        render();
         saveState();
     }
 
-    btnCA.addEventListener("click", function () { switchCountry("ca"); });
-    btnUS.addEventListener("click", function () { switchCountry("us"); });
+    $("btn-ca").addEventListener("click", function () { switchCountry("ca"); });
+    $("btn-us").addEventListener("click", function () { switchCountry("us"); });
 
-    // --- Down payment / loan amount sync ---
+    // ===== LOAN SYNC =====
 
     function syncLoan() {
-        var hv = parseFloat(homeValueInput.value) || 0;
-        var dp = parseFloat(downPaymentInput.value) || 0;
-        if (dp > hv) {
-            dp = hv;
-            downPaymentInput.value = dp;
-        }
+        var hv = parseFloat($("home-value").value) || 0;
+        var dp = parseFloat($("down-payment").value) || 0;
+        if (dp > hv) { dp = hv; $("down-payment").value = dp; }
         var loan = hv - dp;
-        var cfg = countryConfig[country];
-
-        // Canada: CMHC premium added to loan if down payment < 20%
-        var cmhcPremium = 0;
-        if (country === "ca" && loan > 0) {
-            var downPct = hv > 0 ? dp / hv * 100 : 0;
-            if (downPct < 20) {
-                var cmhcRate = cfg.pmiEstimate(downPct);
-                cmhcPremium = loan * cmhcRate / 100;
-                // CMHC premium can be added to the mortgage
-                loan += cmhcPremium;
-            }
-        }
-
-        loanAmountInput.value = Math.round(loan);
         var pct = hv > 0 ? (dp / hv * 100) : 0;
-        downPctEl.textContent = pct.toFixed(0) + "%";
+        $("down-pct").textContent = pct.toFixed(0) + "%";
 
-        // Insurance visibility
-        if (pct < 20 && (hv - dp) > 0) {
-            pmiRow.style.display = "block";
-            if (country === "ca") {
-                if (parseFloat(pmiInput.value) === 0) {
-                    pmiInput.value = cfg.pmiEstimate(pct);
-                }
-                pmiHint.textContent = "CMHC premium of " + fmt(cmhcPremium) + " added to loan. Down payment under 20% requires default insurance.";
-            } else {
-                if (parseFloat(pmiInput.value) === 0) {
-                    pmiInput.value = cfg.pmiEstimate(pct);
-                }
-                pmiHint.textContent = "Down payment under 20%: PMI typically required until 78-80% LTV. Adjust rate as needed.";
-            }
+        var cmhcPremium = 0;
+        var cmhcRow = $("cmhc-row");
+        if (country === "ca" && loan > 0 && pct < 20) {
+            cmhcPremium = calcCmhcPremium(loan, pct);
+            loan += cmhcPremium;
+            $("cmhc-amount").textContent = "CMHC insurance: " + fmt(cmhcPremium) + " added to principal";
+            cmhcRow.style.display = "block";
+            $("cmhc-eligibility").style.display = "flex";
+            var warnings = getCmhcWarnings(hv, pct, parseInt($("amortization").value) || 25);
+            var warnHtml = "";
+            warnings.forEach(function (w) { warnHtml += "<div class=\"warning-text\">" + w + "</div>"; });
+            $("cmhc-warnings").innerHTML = warnHtml;
         } else {
-            pmiRow.style.display = "none";
-            pmiHint.textContent = "";
+            cmhcRow.style.display = "none";
         }
+
+        $("loan-amount").value = Math.round(loan);
     }
 
-    homeValueInput.addEventListener("input", syncLoan);
-    downPaymentInput.addEventListener("input", syncLoan);
+    $("home-value").addEventListener("input", syncLoan);
+    $("down-payment").addEventListener("input", syncLoan);
 
-    // --- Term UI ---
+    // ===== TERMS UI =====
 
     function renderTerms() {
+        var termsList = $("terms-list");
         termsList.innerHTML = "";
         terms.forEach(function (term, i) {
             var maxDuration = country === "ca" ? 10 : 40;
@@ -440,25 +399,17 @@
                 '<div class="term-fields">' +
                 '<div class="field"><label>Duration</label><div class="input-wrap"><input type="number" data-idx="' + i + '" data-field="years" value="' + term.years + '" min="1" max="' + maxDuration + '" step="1"><span class="suffix">yr</span></div></div>' +
                 '<div class="field"><label>Rate</label><div class="input-wrap"><input type="number" data-idx="' + i + '" data-field="rate" value="' + term.rate + '" min="0" max="30" step="0.01"><span class="suffix">%</span></div></div>' +
-                '<div class="field"><label>Schedule</label><select data-idx="' + i + '" data-field="schedule"><option value="monthly"' + (term.schedule === "monthly" ? " selected" : "") + '>Monthly</option><option value="biweekly"' + (term.schedule === "biweekly" ? " selected" : "") + '>Bi-weekly</option><option value="weekly"' + (term.schedule === "weekly" ? " selected" : "") + '>Weekly</option></select></div>' +
                 '</div>';
             termsList.appendChild(card);
         });
 
-        var termInputHandler = function () {
-            var idx = parseInt(this.dataset.idx, 10);
-            var field = this.dataset.field;
-            if (field === "schedule") {
-                terms[idx][field] = this.value;
-            } else {
+        termsList.querySelectorAll("input").forEach(function (el) {
+            el.addEventListener("input", function () {
+                var idx = parseInt(this.dataset.idx, 10);
+                var field = this.dataset.field;
                 terms[idx][field] = parseFloat(this.value) || 0;
-            }
-            render();
-        };
-
-        termsList.querySelectorAll("input, select").forEach(function (el) {
-            el.addEventListener("input", termInputHandler);
-            el.addEventListener("change", termInputHandler);
+                render();
+            });
         });
 
         termsList.querySelectorAll(".remove-term").forEach(function (btn) {
@@ -470,98 +421,273 @@
         });
     }
 
-    addTermBtn.addEventListener("click", function () {
+    $("add-term").addEventListener("click", function () {
         var cfg = countryConfig[country];
         var lastRate = terms.length > 0 ? terms[terms.length - 1].rate : 5;
-        terms.push({ years: cfg.newTermDuration, rate: Math.max(0.5, lastRate - 0.2), schedule: "monthly" });
+        terms.push({ years: cfg.newTermDuration, rate: Math.max(0.5, lastRate - 0.2) });
         renderTerms();
         render();
     });
 
-    // --- Simulation ---
+    // ===== SCENARIO MANAGER =====
 
-    function simulateMortgage(principal, amortYears, termDefs, annualIncrease, lumpAnnual, lumpTerm, annualTax, annualInsurance, monthlyHOA, annualPMI, startMonth, startYear) {
+    function initScenarios() {
+        scenarios = [
+            { id: "base", label: "Base", locked: true, color: baseColor, visible: true },
+        ];
+    }
+
+    function renderScenarioChips() {
+        var container = $("scenario-chips");
+        container.innerHTML = "";
+        scenarios.forEach(function (sc) {
+            var chip = document.createElement("span");
+            chip.className = "scenario-chip" + (sc.visible ? " active" : "") + (sc.locked ? " locked" : "");
+            chip.style.borderColor = sc.visible ? sc.color : "";
+            chip.dataset.id = sc.id;
+            chip.innerHTML =
+                '<span class="chip-dot" style="background:' + sc.color + '"></span>' +
+                sc.label +
+                (!sc.locked ?
+                    ' <button class="chip-edit" data-id="' + sc.id + '" title="Edit">&#9998;</button>' +
+                    ' <button class="chip-delete" data-id="' + sc.id + '" title="Delete">&times;</button>'
+                    : '');
+            container.appendChild(chip);
+        });
+
+        container.querySelectorAll(".scenario-chip").forEach(function (el) {
+            el.addEventListener("click", function (e) {
+                if (e.target.classList.contains("chip-edit") || e.target.classList.contains("chip-delete")) return;
+                var id = el.dataset.id;
+                var sc = scenarios.find(function (s) { return s.id === id; });
+                if (sc && !sc.locked) {
+                    sc.visible = !sc.visible;
+                    renderScenarioChips();
+                    render();
+                }
+            });
+        });
+
+        container.querySelectorAll(".chip-edit").forEach(function (btn) {
+            btn.addEventListener("click", function () { showScenarioEditor(btn.dataset.id); });
+        });
+
+        container.querySelectorAll(".chip-delete").forEach(function (btn) {
+            btn.addEventListener("click", function () { deleteScenario(btn.dataset.id); });
+        });
+    }
+
+    function showScenarioEditor(id) {
+        var editor = $("scenario-editor");
+        var sc = id ? scenarios.find(function (s) { return s.id === id; }) : null;
+        editingScenarioId = id || null;
+
+        var label = sc ? sc.label : "Scenario " + scenarios.length;
+        var color = sc ? sc.color : getNextColor();
+        var mode = sc ? (sc.mode || "offset") : "offset";
+        var offset = sc ? (sc.offset || 0) : 0;
+        var termRates = sc && sc.termRates ? sc.termRates.slice() : terms.map(function (t) { return t.rate; });
+
+        var html =
+            '<div class="input-row">' +
+            '<div class="field"><label>Label</label><div class="input-wrap"><input type="text" id="sc-label-input" value="' + label + '"></div></div>' +
+            '<div class="field"><label>Color</label><div class="color-swatches" id="sc-color-swatches">' +
+            scenarioPresetColors.map(function (c) {
+                return '<button class="color-swatch' + (c === color ? " selected" : "") + '" style="background:' + c + '" data-color="' + c + '"></button>';
+            }).join("") +
+            '</div></div>' +
+            '</div>' +
+            '<div class="input-row">' +
+            '<div class="field"><label>Mode</label><select id="sc-mode-select">' +
+            '<option value="offset"' + (mode === "offset" ? " selected" : "") + '>Offset from base</option>' +
+            '<option value="custom"' + (mode === "custom" ? " selected" : "") + '>Custom rates</option>' +
+            '</select></div>' +
+            '<div class="field" id="sc-offset-field"' + (mode !== "offset" ? ' style="display:none"' : '') + '><label>Offset</label><div class="input-wrap"><input type="number" id="sc-offset-input" value="' + offset + '" step="0.25"><span class="suffix">%</span></div></div>' +
+            '</div>' +
+            '<div id="sc-custom-rates"' + (mode !== "custom" ? ' style="display:none"' : '') + '>' +
+            '<div class="custom-rates-list">' +
+            terms.map(function (t, i) {
+                return '<div class="custom-rate-row"><span class="term-label">Term ' + (i + 1) + '</span><div class="input-wrap"><input type="number" class="sc-custom-rate" data-idx="' + i + '" value="' + (termRates[i] !== undefined ? termRates[i] : t.rate) + '" step="0.01"><span class="suffix">%</span></div></div>';
+            }).join("") +
+            '</div></div>' +
+            '<div class="scenario-editor-actions">' +
+            '<button class="btn-link" id="sc-save-btn">Save</button>' +
+            '<button class="btn-link" id="sc-cancel-btn">Cancel</button>' +
+            '</div>';
+
+        editor.innerHTML = html;
+        editor.classList.add("visible");
+
+        $("sc-mode-select").addEventListener("change", function () {
+            var isOffset = this.value === "offset";
+            $("sc-offset-field").style.display = isOffset ? "" : "none";
+            $("sc-custom-rates").style.display = isOffset ? "none" : "";
+        });
+
+        $("sc-color-swatches").querySelectorAll(".color-swatch").forEach(function (sw) {
+            sw.addEventListener("click", function () {
+                $("sc-color-swatches").querySelectorAll(".color-swatch").forEach(function (s) { s.classList.remove("selected"); });
+                sw.classList.add("selected");
+            });
+        });
+
+        $("sc-save-btn").addEventListener("click", saveScenario);
+        $("sc-cancel-btn").addEventListener("click", hideScenarioEditor);
+    }
+
+    function hideScenarioEditor() {
+        $("scenario-editor").innerHTML = "";
+        $("scenario-editor").classList.remove("visible");
+        editingScenarioId = null;
+    }
+
+    function saveScenario() {
+        var label = $("sc-label-input").value || "Scenario";
+        var selectedSwatch = $("sc-color-swatches").querySelector(".color-swatch.selected");
+        var color = selectedSwatch ? selectedSwatch.dataset.color : baseColor;
+        var mode = $("sc-mode-select").value;
+        var offset = parseFloat($("sc-offset-input").value) || 0;
+        var termRates = [];
+        document.querySelectorAll(".sc-custom-rate").forEach(function (inp) {
+            termRates.push(parseFloat(inp.value) || 0);
+        });
+
+        if (editingScenarioId) {
+            var sc = scenarios.find(function (s) { return s.id === editingScenarioId; });
+            if (sc) {
+                sc.label = label;
+                sc.color = color;
+                sc.mode = mode;
+                sc.offset = offset;
+                if (mode === "custom") sc.termRates = termRates;
+                else delete sc.termRates;
+            }
+        } else {
+            if (scenarios.length >= 5) return;
+            var newId = "s" + Date.now();
+            var newSc = { id: newId, label: label, mode: mode, offset: offset, color: color, visible: true };
+            if (mode === "custom") newSc.termRates = termRates;
+            scenarios.push(newSc);
+        }
+
+        hideScenarioEditor();
+        renderScenarioChips();
+        render();
+        saveState();
+    }
+
+    function deleteScenario(id) {
+        scenarios = scenarios.filter(function (s) { return s.id !== id; });
+        renderScenarioChips();
+        render();
+        saveState();
+    }
+
+    function getNextColor() {
+        var usedColors = scenarios.map(function (s) { return s.color; });
+        for (var i = 0; i < scenarioPresetColors.length; i++) {
+            if (usedColors.indexOf(scenarioPresetColors[i]) === -1) return scenarioPresetColors[i];
+        }
+        return scenarioPresetColors[scenarios.length % scenarioPresetColors.length];
+    }
+
+    function getScenarioTermDefs(scenario) {
+        if (scenario.id === "base") return terms;
+        if (scenario.mode === "offset") {
+            return terms.map(function (t) { return { years: t.years, rate: Math.max(0, t.rate + (scenario.offset || 0)) }; });
+        }
+        if (scenario.mode === "custom") {
+            return terms.map(function (t, i) {
+                return { years: t.years, rate: (scenario.termRates && i < scenario.termRates.length) ? scenario.termRates[i] : t.rate };
+            });
+        }
+        return terms;
+    }
+
+    $("add-scenario").addEventListener("click", function () {
+        if (scenarios.length >= 5) return;
+        showScenarioEditor(null);
+    });
+
+    // ===== SIMULATION =====
+
+    function simulateMortgage(principal, amortYears, termDefs, freq, annualIncrease, lumpAnnual, lumpTerm, startMonth, startYear) {
         var balance = principal;
         var remainingAmort = amortYears;
         var totalInterest = 0;
         var totalPrincipalPaid = 0;
-        var totalTax = 0;
-        var totalInsurance = 0;
-        var totalHOA = 0;
-        var totalPMI = 0;
         var termResults = [];
         var schedule = [];
-        var globalMonth = 0;
+        var globalPeriod = 0;
         var compounding = countryConfig[country].compounding;
-        var pmiIsOngoing = country === "us"; // US: ongoing PMI, CA: upfront CMHC (already in loan)
+        var ppy = frequencyConfig[freq].ppy;
+        var cumulativeInterest = 0;
+        var annualSnapshots = [{ year: 0, balance: principal, cumulativeInterest: 0, annualPrincipal: 0, annualInterest: 0, termIndex: 0, payment: 0 }];
+        var yearPrincipal = 0;
+        var yearInterest = 0;
+        var currentPaymentYear = 0;
 
         for (var ti = 0; ti < termDefs.length && balance > 0.01; ti++) {
             var term = termDefs[ti];
-            var ppy = schedulePaymentsPerYear(term.schedule);
-
-            var r = effectivePeriodRate(term.rate, term.schedule, compounding);
-
-            var termPayments = term.years * ppy;
-
-            var basePayment = calcBasePayment(balance, term.rate, remainingAmort, term.schedule, compounding);
+            var r = effectivePeriodRate(term.rate, freq, compounding);
+            var termPeriods = term.years * ppy;
+            var basePayment = calcPeriodicPayment(balance, term.rate, remainingAmort, freq, compounding);
             var payment = basePayment;
             var paymentsThisYear = 0;
             var termPrincipal = 0;
             var termInterest = 0;
-            var termTax = 0;
-            var termInsurance = 0;
-            var termHOA = 0;
-            var termPMI = 0;
 
-            for (var p = 0; p < termPayments && balance > 0.01; p++) {
-                // Annual payment increase
+            for (var p = 0; p < termPeriods && balance > 0.01; p++) {
                 if (p > 0 && p % ppy === 0) {
                     payment += annualIncrease;
-                    paymentsThisYear = 0;
+                    // Emit annual snapshot at year boundary
+                    currentPaymentYear++;
+                    annualSnapshots.push({
+                        year: currentPaymentYear,
+                        balance: Math.max(0, balance),
+                        cumulativeInterest: cumulativeInterest,
+                        annualPrincipal: yearPrincipal,
+                        annualInterest: yearInterest,
+                        termIndex: ti,
+                        payment: payment,
+                    });
+                    yearPrincipal = 0;
+                    yearInterest = 0;
                 }
 
                 var interestPortion = balance * r;
                 var principalPortion = payment - interestPortion;
-                if (principalPortion > balance) {
-                    principalPortion = balance;
-                }
-
-                // PMI (US only: ongoing until 78-80% LTV)
-                var pmiPortion = 0;
-                if (pmiIsOngoing) {
-                    var downPct = principal > 0 ? ((parseFloat(homeValueInput.value) - balance) / parseFloat(homeValueInput.value) * 100) : 100;
-                    if (downPct < 20) {
-                        pmiPortion = (annualPMI / 100 * balance) / ppy;
-                    }
-                }
+                if (principalPortion > balance) principalPortion = balance;
 
                 balance -= principalPortion;
                 termPrincipal += principalPortion;
                 termInterest += interestPortion;
-                termPMI += pmiPortion;
-
+                cumulativeInterest += interestPortion;
+                yearPrincipal += principalPortion;
+                yearInterest += interestPortion;
                 paymentsThisYear++;
 
-                // Schedule row
-                var absMonth = (startMonth + globalMonth) % 12;
-                var absYear = startYear + Math.floor((startMonth + globalMonth) / 12);
+                var periodInYear = globalPeriod % ppy;
+                var yearFromStart = Math.floor(globalPeriod / ppy);
+                var absMonth = (startMonth + Math.floor(globalPeriod * 12 / ppy)) % 12;
+                var absYear = startYear + Math.floor((startMonth + globalPeriod * 12 / ppy) / 12);
+
                 schedule.push({
+                    period: globalPeriod,
+                    periodInYear: periodInYear,
+                    yearFromStart: yearFromStart,
                     month: absMonth,
                     year: absYear,
                     termIndex: ti,
-                    payment: principalPortion + interestPortion + pmiPortion,
+                    payment: principalPortion + interestPortion,
                     principal: principalPortion,
                     interest: interestPortion,
-                    pmi: pmiPortion,
-                    tax: annualTax / ppy,
-                    insurance: annualInsurance / ppy,
-                    hoa: monthlyHOA * 12 / ppy,
                     balance: Math.max(0, balance),
+                    cumulativeInterest: cumulativeInterest,
                 });
 
-                globalMonth++;
+                globalPeriod++;
 
-                // Annual lump sum
                 if (lumpAnnual > 0 && paymentsThisYear === ppy && balance > 0.01) {
                     var lumpApply = Math.min(lumpAnnual, balance);
                     balance -= lumpApply;
@@ -569,158 +695,207 @@
                 }
             }
 
-            // Lump sum at renewal
             if (lumpTerm > 0 && balance > 0.01) {
                 var lumpApplyTerm = Math.min(lumpTerm, balance);
                 balance -= lumpApplyTerm;
                 termPrincipal += lumpApplyTerm;
             }
 
-            var termYears = term.years;
-            termTax = annualTax * termYears;
-            termInsurance = annualInsurance * termYears;
-            termHOA = monthlyHOA * 12 * termYears;
-
             totalInterest += termInterest;
             totalPrincipalPaid += termPrincipal;
-            totalTax += termTax;
-            totalInsurance += termInsurance;
-            totalHOA += termHOA;
-            totalPMI += termPMI;
-
             remainingAmort -= term.years;
             if (remainingAmort < 1) remainingAmort = 1;
 
-            var insuranceLabel = country === "ca" ? "CMHC" : "PMI";
+            var remainingYears = 0;
+            var remainingMonths = 0;
+            if (balance > 0.01) {
+                remainingYears = Math.max(0, remainingAmort);
+                remainingMonths = 0;
+            }
 
             termResults.push({
                 index: ti,
                 years: term.years,
                 rate: term.rate,
-                schedule: term.schedule,
                 basePayment: basePayment,
                 principalPaid: termPrincipal,
                 interestPaid: termInterest,
+                cumulativeInterest: cumulativeInterest,
                 balanceAtEnd: balance,
                 totalPayments: termPrincipal + termInterest,
-                tax: termTax,
-                insurance: termInsurance,
-                hoa: termHOA,
-                pmi: termPMI,
-                pmiLabel: insuranceLabel,
+                remainingYears: remainingYears,
+                remainingMonths: remainingMonths,
             });
+        }
 
+        // Final annual snapshot if there is leftover year data
+        if (yearPrincipal > 0 || yearInterest > 0) {
+            currentPaymentYear++;
+            annualSnapshots.push({
+                year: currentPaymentYear,
+                balance: Math.max(0, balance),
+                cumulativeInterest: cumulativeInterest,
+                annualPrincipal: yearPrincipal,
+                annualInterest: yearInterest,
+                termIndex: termResults.length > 0 ? termResults[termResults.length - 1].index : 0,
+                payment: termResults.length > 0 ? termResults[termResults.length - 1].basePayment : 0,
+            });
         }
 
         return {
             totalInterest: totalInterest,
             totalPrincipalPaid: totalPrincipalPaid,
             totalPaid: totalInterest + totalPrincipalPaid,
-            totalTax: totalTax,
-            totalInsurance: totalInsurance,
-            totalHOA: totalHOA,
-            totalPMI: totalPMI,
-            totalAllIn: totalPrincipalPaid + totalInterest + totalTax + totalInsurance + totalHOA + totalPMI,
             termResults: termResults,
             schedule: schedule,
+            annualSnapshots: annualSnapshots,
             paidOff: balance < 0.01,
             principal: principal,
-            pmiLabel: country === "ca" ? "Default Ins." : "PMI",
+            totalPeriods: globalPeriod,
         };
     }
 
-    // --- Results rendering ---
+    function simulateAllScenarios() {
+        var principal = parseFloat($("loan-amount").value) || 0;
+        var amort = parseInt($("amortization").value, 10) || 25;
+        var annualIncrease = parseFloat($("payment-increase").value) || 0;
+        var lumpAnnual = parseFloat($("lump-sum-annual").value) || 0;
+        var lumpTerm = parseFloat($("lump-sum-term").value) || 0;
+        var startMonth = parseInt($("start-month").value, 10) || 0;
+        var startYear = parseInt($("start-year").value, 10) || 2026;
+
+        var results = { base: null, scenarios: {} };
+
+        // Base scenario
+        results.base = simulateMortgage(principal, amort, terms, paymentFrequency, annualIncrease, lumpAnnual, lumpTerm, startMonth, startYear);
+
+        // Non-base scenarios
+        scenarios.forEach(function (sc) {
+            if (sc.id === "base" || !sc.visible) return;
+            var termDefs = getScenarioTermDefs(sc);
+            results.scenarios[sc.id] = simulateMortgage(principal, amort, termDefs, paymentFrequency, annualIncrease, lumpAnnual, lumpTerm, startMonth, startYear);
+        });
+
+        lastSimResults = results;
+        return results;
+    }
+
+    // ===== RESULTS RENDERING =====
 
     function render() {
-        var principal = parseFloat(loanAmountInput.value) || 0;
-        var amort = parseInt(amortInput.value, 10) || 25;
-        var annualIncrease = parseFloat(paymentIncreaseInput.value) || 0;
-        var lumpAnnual = parseFloat(lumpSumAnnualInput.value) || 0;
-        var lumpTerm = parseFloat(lumpSumTermInput.value) || 0;
-        var annualTax = parseFloat(propertyTaxInput.value) || 0;
-        var annualInsurance = parseFloat(homeInsuranceInput.value) || 0;
-        var monthlyHOA = parseFloat(hoaInput.value) || 0;
-        var annualPMI = parseFloat(pmiInput.value) || 0;
-        var startMonth = parseInt(startMonthInput.value, 10) || 0;
-        var startYear = parseInt(startYearInput.value, 10) || 2026;
+        var principal = parseFloat($("loan-amount").value) || 0;
+        var amort = parseInt($("amortization").value, 10) || 25;
 
         if (principal <= 0 || terms.length === 0) {
-            resultsEl.classList.remove("visible");
-            chartSection.classList.remove("visible");
-            pieSection.classList.remove("visible");
-            scheduleSection.style.display = "none";
+            $("results").classList.remove("visible");
+            $("savings-cards").classList.remove("visible");
+            $("charts-container").classList.remove("visible");
+            $("schedule-section").style.display = "none";
+            $("export-section").classList.remove("visible");
             return;
         }
 
-        var sim = simulateMortgage(principal, amort, terms, annualIncrease, lumpAnnual, lumpTerm, annualTax, annualInsurance, monthlyHOA, annualPMI, startMonth, startYear);
-        lastSimResult = sim;
+        var results = simulateAllScenarios();
+        var sim = results.base;
 
         // Update hook
-        hookLoan.textContent = fmt(principal);
-        hookInterest.textContent = fmt(sim.totalInterest);
+        $("hook-loan").textContent = fmt(principal);
+        $("hook-interest").textContent = fmt(sim.totalInterest);
 
-        // Summary
+        // Summary cards
         var html =
             '<div class="result-summary">' +
-            '<div class="summary-card"><div class="label">Total Cost (All-In)</div><div class="value">' + fmt(sim.totalAllIn) + '</div></div>' +
+            '<div class="summary-card"><div class="label">Total Paid</div><div class="value">' + fmt(sim.totalPaid) + '</div></div>' +
             '<div class="summary-card"><div class="label">Total Interest</div><div class="value">' + fmt(sim.totalInterest) + '</div></div>' +
             '<div class="summary-card accent"><div class="label">Interest / Payments</div><div class="value">' + fmtPct(sim.totalPaid > 0 ? sim.totalInterest / sim.totalPaid * 100 : 0) + '</div></div>' +
             '</div>';
 
-        // Bi-weekly comparison
-        var firstTerm = sim.termResults[0];
-        if (firstTerm && firstTerm.schedule === "monthly") {
-            var monthlyPay = firstTerm.basePayment;
-            var biweeklyPay = monthlyPay / 2;
-            var biweeklyAnnual = biweeklyPay * 26;
-            var monthlyAnnual = monthlyPay * 12;
-            var extraPerYear = biweeklyAnnual - monthlyAnnual;
-            html += '<div class="biweekly-compare">Switch to bi-weekly payments of <strong>' + fmtFull(biweeklyPay) + '</strong>? That puts <strong>' + fmt(extraPerYear) + ' extra/year</strong> toward your mortgage, cutting years off the amortization.</div>';
+        // CMHC premium card
+        var hv = parseFloat($("home-value").value) || 0;
+        var dp = parseFloat($("down-payment").value) || 0;
+        var pct = hv > 0 ? (dp / hv * 100) : 0;
+        if (country === "ca" && pct < 20 && hv > dp) {
+            var cmhcPrem = calcCmhcPremium(hv - dp, pct);
+            html += '<div class="summary-card" style="margin-bottom:1.25rem"><div class="label">CMHC Premium (in principal)</div><div class="value">' + fmt(cmhcPrem) + '</div></div>';
+        }
+
+        // Frequency comparison hint
+        if (paymentFrequency.startsWith("accelerated_")) {
+            var monthlyPmt = calcMonthlyPayment(principal, terms[0].rate, amort, countryConfig[country].compounding);
+            html += '<div class="freq-compare">Accelerated ' + freqLabel().replace("Accelerated ", "").toLowerCase() + ' payments of <strong>' + fmtFull(calcPeriodicPayment(principal, terms[0].rate, amort, paymentFrequency, countryConfig[country].compounding)) + '</strong> put ~1 extra monthly payment per year toward your mortgage.</div>';
         }
 
         // Per-term breakdown
         sim.termResults.forEach(function (tr, i) {
+            var remainingText = "";
+            if (tr.balanceAtEnd > 0.01) {
+                remainingText = '<div class="term-remaining">' + tr.remainingYears + ' yr remaining on amortization</div>';
+            }
             html +=
                 '<div class="term-result">' +
-                '<h4>Term ' + (i + 1) + ' &mdash; ' + tr.years + ' yr @ ' + tr.rate + '% (' + scheduleLabel(tr.schedule) + ')</h4>' +
+                '<h4>Term ' + (i + 1) + ' &mdash; ' + tr.years + ' yr @ ' + tr.rate + '% (' + freqLabel() + ')</h4>' +
                 '<dl class="term-result-grid">' +
-                '<div><dt>Payment</dt><dd>' + fmtFull(tr.basePayment) + '</dd></div>' +
+                '<div><dt>Payment</dt><dd>' + fmtFull(tr.basePayment) + freqSuffix() + '</dd></div>' +
                 '<div><dt>Principal Paid</dt><dd>' + fmt(tr.principalPaid) + '</dd></div>' +
                 '<div><dt>Interest Paid</dt><dd>' + fmt(tr.interestPaid) + '</dd></div>' +
-                '<div><dt>Total P&I</dt><dd>' + fmt(tr.totalPayments) + '</dd></div>' +
                 '<div><dt>Balance at End</dt><dd>' + fmt(tr.balanceAtEnd) + '</dd></div>' +
+                '<div><dt>Cumulative Interest</dt><dd>' + fmt(tr.cumulativeInterest) + '</dd></div>' +
                 '<div><dt>Interest Share</dt><dd>' + fmtPct(tr.totalPayments > 0 ? tr.interestPaid / tr.totalPayments * 100 : 0) + '</dd></div>' +
-                (tr.pmi > 0 ? '<div><dt>' + tr.pmiLabel + '</dt><dd>' + fmt(tr.pmi) + '</dd></div>' : '') +
                 '</dl>' +
+                remainingText +
                 '</div>';
         });
 
-        // Scenario comparison
-        var optOffset = parseFloat(rateOptimisticInput.value) || 0;
-        var pessOffset = parseFloat(ratePessimisticInput.value) || 0;
-        if (optOffset !== 0 || pessOffset !== 0) {
-            var optTerms = terms.map(function (t) { return { years: t.years, rate: Math.max(0, t.rate + optOffset), schedule: t.schedule }; });
-            var pessTerms = terms.map(function (t) { return { years: t.years, rate: t.rate + pessOffset, schedule: t.schedule }; });
-            var simOpt = simulateMortgage(principal, amort, optTerms, annualIncrease, lumpAnnual, lumpTerm, annualTax, annualInsurance, monthlyHOA, annualPMI, startMonth, startYear);
-            var simPess = simulateMortgage(principal, amort, pessTerms, annualIncrease, lumpAnnual, lumpTerm, annualTax, annualInsurance, monthlyHOA, annualPMI, startMonth, startYear);
+        // Scenario comparison table
+        var visibleScenarios = scenarios.filter(function (s) { return s.visible && s.id !== "base"; });
+        if (visibleScenarios.length > 0) {
+            html += '<div class="scenario-compare"><table class="scenario-table"><thead><tr><th></th>';
+            html += '<th><span class="scenario-label"><span class="chip-dot" style="background:' + baseColor + '"></span>Base</span></th>';
+            visibleScenarios.forEach(function (sc) {
+                html += '<th><span class="scenario-label"><span class="chip-dot" style="background:' + sc.color + '"></span>' + sc.label + '</span></th>';
+            });
+            html += '</tr></thead><tbody>';
 
-            html +=
-                '<div class="scenario-compare">' +
-                '<table class="scenario-table">' +
-                '<thead><tr><th></th>' +
-                '<th><span class="scenario-label opt">Optimistic (' + fmtPct(optOffset) + ')</span></th>' +
-                '<th>Base</th>' +
-                '<th><span class="scenario-label pess">Pessimistic (+' + fmtPct(pessOffset) + ')</span></th>' +
-                '</tr></thead><tbody>' +
-                '<tr><td>' + scheduleLabel(terms[0].schedule).charAt(0).toUpperCase() + scheduleLabel(terms[0].schedule).slice(1) + ' Payment</td><td>' + fmtFull(simOpt.termResults[0].basePayment) + '</td><td>' + fmtFull(sim.termResults[0].basePayment) + '</td><td>' + fmtFull(simPess.termResults[0].basePayment) + '</td></tr>' +
-                '<tr><td>Total Interest</td><td>' + fmt(simOpt.totalInterest) + '</td><td>' + fmt(sim.totalInterest) + '</td><td>' + fmt(simPess.totalInterest) + '</td></tr>' +
-                '<tr><td>Total Cost</td><td>' + fmt(simOpt.totalAllIn) + '</td><td>' + fmt(sim.totalAllIn) + '</td><td>' + fmt(simPess.totalAllIn) + '</td></tr>' +
-                '<tr><td>Interest Share</td><td>' + fmtPct(simOpt.totalPaid > 0 ? simOpt.totalInterest / simOpt.totalPaid * 100 : 0) + '</td><td>' + fmtPct(sim.totalPaid > 0 ? sim.totalInterest / sim.totalPaid * 100 : 0) + '</td><td>' + fmtPct(simPess.totalPaid > 0 ? simPess.totalInterest / simPess.totalPaid * 100 : 0) + '</td></tr>' +
-                '<tr><td>Paid Off</td><td>' + (simOpt.paidOff ? 'Yes' : 'No') + '</td><td>' + (sim.paidOff ? 'Yes' : 'No') + '</td><td>' + (simPess.paidOff ? 'Yes' : 'No') + '</td></tr>' +
-                '</tbody></table></div>';
+            var firstTerm = sim.termResults[0];
+            html += '<tr><td>' + freqLabel() + ' Payment</td><td>' + (firstTerm ? fmtFull(firstTerm.basePayment) : "-") + '</td>';
+            visibleScenarios.forEach(function (sc) {
+                var scSim = results.scenarios[sc.id];
+                html += '<td>' + (scSim && scSim.termResults[0] ? fmtFull(scSim.termResults[0].basePayment) : "-") + '</td>';
+            });
+            html += '</tr>';
+
+            html += '<tr><td>Total Interest</td><td>' + fmt(sim.totalInterest) + '</td>';
+            visibleScenarios.forEach(function (sc) {
+                var scSim = results.scenarios[sc.id];
+                html += '<td>' + (scSim ? fmt(scSim.totalInterest) : "-") + '</td>';
+            });
+            html += '</tr>';
+
+            html += '<tr><td>Total Paid</td><td>' + fmt(sim.totalPaid) + '</td>';
+            visibleScenarios.forEach(function (sc) {
+                var scSim = results.scenarios[sc.id];
+                html += '<td>' + (scSim ? fmt(scSim.totalPaid) : "-") + '</td>';
+            });
+            html += '</tr>';
+
+            html += '<tr><td>Interest Share</td><td>' + fmtPct(sim.totalPaid > 0 ? sim.totalInterest / sim.totalPaid * 100 : 0) + '</td>';
+            visibleScenarios.forEach(function (sc) {
+                var scSim = results.scenarios[sc.id];
+                html += '<td>' + (scSim ? fmtPct(scSim.totalPaid > 0 ? scSim.totalInterest / scSim.totalPaid * 100 : 0) : "-") + '</td>';
+            });
+            html += '</tr>';
+
+            html += '<tr><td>Paid Off</td><td>' + (sim.paidOff ? "Yes" : "No") + '</td>';
+            visibleScenarios.forEach(function (sc) {
+                var scSim = results.scenarios[sc.id];
+                html += '<td>' + (scSim ? (scSim.paidOff ? "Yes" : "No") : "-") + '</td>';
+            });
+            html += '</tr>';
+
+            html += '</tbody></table></div>';
         }
 
-        // Missing years to amortization
+        // Missing years
         var totalTermYears = 0;
         terms.forEach(function (t) { totalTermYears += t.years; });
         var missingYears = amort - totalTermYears;
@@ -737,226 +912,424 @@
             html += '<p class="hint warning">Mortgage not fully paid after all terms. Remaining balance: ' + fmt(sim.termResults[sim.termResults.length - 1].balanceAtEnd) + '</p>';
         }
 
-        resultsEl.innerHTML = html;
-        resultsEl.classList.add("visible");
+        $("results").innerHTML = html;
+        $("results").classList.add("visible");
 
-        drawInterestChart(sim);
-        chartSection.classList.add("visible");
+        // Savings cards
+        renderSavingsCards(results);
 
-        drawPieChart(sim);
-        pieSection.classList.add("visible");
+        // Charts
+        renderCharts(results);
 
+        // Schedule
         renderSchedule(sim);
+
+        // Export
+        $("export-section").classList.add("visible");
+
         saveState();
     }
 
-    // --- Interest per term bar chart ---
+    // ===== SAVINGS CARDS =====
 
-    function cssVar(name) {
-        return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    function renderSavingsCards(results) {
+        var sim = results.base;
+        var visibleScenarios = scenarios.filter(function (s) { return s.visible && s.id !== "base"; });
+        if (visibleScenarios.length === 0) {
+            $("savings-cards").classList.remove("visible");
+            $("savings-cards").innerHTML = "";
+            return;
+        }
+
+        var html = '<div class="savings-cards-row">';
+        visibleScenarios.forEach(function (sc) {
+            var scSim = results.scenarios[sc.id];
+            if (!scSim) return;
+
+            var interestDelta = scSim.totalInterest - sim.totalInterest;
+            var baseMonths = sim.totalPeriods;
+            var scMonths = scSim.totalPeriods;
+            var monthDelta = scMonths - baseMonths;
+            var balanceAtFirstRenewal = sim.termResults.length > 0 ? sim.termResults[0].balanceAtEnd : 0;
+            var scBalanceAtFirstRenewal = scSim.termResults.length > 0 ? scSim.termResults[0].balanceAtEnd : 0;
+            var balanceDelta = scBalanceAtFirstRenewal - balanceAtFirstRenewal;
+
+            var interestClass = interestDelta < 0 ? "negative" : "positive";
+            var paidOffText = monthDelta < 0 ? Math.abs(monthDelta) + " periods early" : monthDelta > 0 ? monthDelta + " periods late" : "same";
+            var balanceClass = balanceDelta < 0 ? "negative" : balanceDelta > 0 ? "positive" : "";
+
+            html +=
+                '<div class="savings-card">' +
+                '<div class="savings-card-header"><span class="chip-dot" style="background:' + sc.color + '"></span>' + sc.label + '</div>' +
+                '<div class="savings-card-row"><span>Total interest</span><span class="delta ' + interestClass + '">' + (interestDelta >= 0 ? "+" : "") + fmt(interestDelta) + '</span></div>' +
+                '<div class="savings-card-row"><span>Paid off</span><span class="delta ' + (monthDelta <= 0 ? "negative" : "positive") + '">' + paidOffText + '</span></div>' +
+                '<div class="savings-card-row"><span>Balance at first renewal</span><span class="delta ' + balanceClass + '">' + (balanceDelta >= 0 ? "+" : "") + fmt(balanceDelta) + '</span></div>' +
+                '</div>';
+        });
+        html += '</div>';
+
+        $("savings-cards").innerHTML = html;
+        $("savings-cards").classList.add("visible");
     }
 
-    function drawInterestChart(sim) {
-        var canvas = document.getElementById("interestChart");
-        var dpr = window.devicePixelRatio || 1;
-        var rect = canvas.getBoundingClientRect();
-        canvas.width = rect.width * dpr;
-        canvas.height = rect.height * dpr;
-        var ctx = canvas.getContext("2d");
-        ctx.scale(dpr, dpr);
+    // ===== CHARTS =====
 
-        var W = rect.width;
-        var H = rect.height;
-        var pad = { top: 25, right: 20, bottom: 40, left: 60 };
-        var plotW = W - pad.left - pad.right;
-        var plotH = H - pad.top - pad.bottom;
+    function renderCharts(results) {
+        var container = $("charts-container");
+        container.classList.add("visible");
 
-        ctx.clearRect(0, 0, W, H);
+        if (typeof Chart === "undefined") {
+            container.innerHTML = "<p class='hint'>Charts require an internet connection to load Chart.js.</p>";
+            return;
+        }
+
+        var sim = results.base;
+        var visibleScenarios = scenarios.filter(function (s) { return s.visible; });
+        var dark = isDark();
+        var gridColor = dark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.06)";
+        var textColor = dark ? "#aaa" : "#555";
+
+        // Term boundary years for annotations
+        var termBoundaries = [];
+        var cumYears = 0;
+        terms.forEach(function (t, i) {
+            cumYears += t.years;
+            termBoundaries.push({ year: cumYears, label: "T" + (i + 1), rate: t.rate });
+        });
+
+        // Chart A: Balance Over Time
+        drawLineChart("balanceChart", results, visibleScenarios, "balance", "Balance Over Time", "Balance ($)", gridColor, textColor, termBoundaries);
+
+        // Chart B: Cumulative Interest
+        drawLineChart("cumulativeInterestChart", results, visibleScenarios, "cumulativeInterest", "Cumulative Interest", "Interest ($)", gridColor, textColor, termBoundaries);
+
+        // Chart C: Payment Over Time (step chart)
+        drawPaymentChart(results, visibleScenarios, gridColor, textColor, termBoundaries);
+
+        // Chart D: Interest vs Principal split
+        drawIPSplitChart(results, gridColor, textColor);
+
+        // Interest per term bar chart
+        drawInterestBarChart(sim, gridColor, textColor);
+    }
+
+    function destroyChart(id) {
+        if (chartInstances[id]) {
+            chartInstances[id].destroy();
+            delete chartInstances[id];
+        }
+    }
+
+    function drawLineChart(canvasId, results, visibleScenarios, field, title, yLabel, gridColor, textColor, termBoundaries) {
+        destroyChart(canvasId);
+        var canvas = $(canvasId);
+        if (!canvas) return;
+
+        var datasets = [];
+        visibleScenarios.forEach(function (sc) {
+            var scSim = sc.id === "base" ? results.base : results.scenarios[sc.id];
+            if (!scSim) return;
+            var data = scSim.annualSnapshots.map(function (s) { return { x: s.year, y: s[field] }; });
+            datasets.push({
+                label: sc.label,
+                data: data,
+                borderColor: sc.color,
+                backgroundColor: sc.color + "20",
+                borderWidth: 2,
+                fill: field === "balance",
+                pointRadius: 0,
+                tension: 0.1,
+            });
+        });
+
+        var annotations = {};
+        termBoundaries.forEach(function (tb, i) {
+            annotations["term" + i] = {
+                type: "line",
+                xMin: tb.year,
+                xMax: tb.year,
+                borderColor: textColor,
+                borderWidth: 1,
+                borderDash: [4, 4],
+                label: {
+                    display: true,
+                    content: tb.label + " (" + tb.rate + "%)",
+                    position: "start",
+                    font: { size: 10 },
+                    backgroundColor: "transparent",
+                    color: textColor,
+                },
+            };
+        });
+
+        chartInstances[canvasId] = new Chart(canvas, {
+            type: "line",
+            data: { datasets: datasets },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: { mode: "index", intersect: false },
+                scales: {
+                    x: {
+                        type: "linear",
+                        title: { display: true, text: "Year", color: textColor },
+                        grid: { color: gridColor },
+                        ticks: { color: textColor, stepSize: 5 },
+                    },
+                    y: {
+                        title: { display: true, text: yLabel, color: textColor },
+                        grid: { color: gridColor },
+                        ticks: {
+                            color: textColor,
+                            callback: function (v) { return v >= 1000 ? "$" + Math.round(v / 1000) + "k" : "$" + v; },
+                        },
+                    },
+                },
+                plugins: {
+                    annotation: { annotations: annotations },
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            label: function (ctx) { return ctx.dataset.label + ": " + fmt(ctx.parsed.y); },
+                        },
+                    },
+                },
+            },
+        });
+    }
+
+    function drawPaymentChart(results, visibleScenarios, gridColor, textColor, termBoundaries) {
+        destroyChart("paymentChart");
+        var canvas = $("paymentChart");
+        if (!canvas) return;
+
+        var datasets = [];
+        visibleScenarios.forEach(function (sc) {
+            var scSim = sc.id === "base" ? results.base : results.scenarios[sc.id];
+            if (!scSim) return;
+            var data = [];
+            scSim.annualSnapshots.forEach(function (s) {
+                if (s.year > 0) data.push({ x: s.year, y: s.payment });
+            });
+            datasets.push({
+                label: sc.label,
+                data: data,
+                borderColor: sc.color,
+                backgroundColor: sc.color + "20",
+                borderWidth: 2,
+                stepped: "before",
+                fill: false,
+                pointRadius: 0,
+            });
+        });
+
+        var annotations = {};
+        termBoundaries.forEach(function (tb, i) {
+            annotations["term" + i] = {
+                type: "line",
+                xMin: tb.year,
+                xMax: tb.year,
+                borderColor: textColor,
+                borderWidth: 1,
+                borderDash: [4, 4],
+                label: {
+                    display: true,
+                    content: tb.label,
+                    position: "start",
+                    font: { size: 10 },
+                    backgroundColor: "transparent",
+                    color: textColor,
+                },
+            };
+        });
+
+        chartInstances["paymentChart"] = new Chart(canvas, {
+            type: "line",
+            data: { datasets: datasets },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: { mode: "index", intersect: false },
+                scales: {
+                    x: {
+                        type: "linear",
+                        title: { display: true, text: "Year", color: textColor },
+                        grid: { color: gridColor },
+                        ticks: { color: textColor, stepSize: 5 },
+                    },
+                    y: {
+                        title: { display: true, text: "Payment (" + freqSuffix().replace("/", "").trim() + ")", color: textColor },
+                        grid: { color: gridColor },
+                        ticks: { color: textColor, callback: function (v) { return fmt(v); } },
+                    },
+                },
+                plugins: {
+                    annotation: { annotations: annotations },
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            label: function (ctx) { return ctx.dataset.label + ": " + fmtFull(ctx.parsed.y) + freqSuffix(); },
+                        },
+                    },
+                },
+            },
+        });
+    }
+
+    function drawIPSplitChart(results, gridColor, textColor) {
+        destroyChart("ipSplitChart");
+        var canvas = $("ipSplitChart");
+        if (!canvas) return;
+
+        // Populate scenario selector
+        var select = $("ip-scenario-select");
+        select.innerHTML = "";
+        scenarios.forEach(function (sc) {
+            if (!sc.visible) return;
+            var opt = document.createElement("option");
+            opt.value = sc.id;
+            opt.textContent = sc.label;
+            select.appendChild(opt);
+        });
+
+        var selectedId = select.value || "base";
+        var sim = selectedId === "base" ? results.base : results.scenarios[selectedId];
+        if (!sim) return;
+
+        var snapshots = sim.annualSnapshots.filter(function (s) { return s.year > 0; });
+        var labels = snapshots.map(function (s) { return s.year; });
+
+        chartInstances["ipSplitChart"] = new Chart(canvas, {
+            type: "bar",
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: "Principal",
+                        data: snapshots.map(function (s) { return s.annualPrincipal; }),
+                        backgroundColor: isDark() ? "#b0b0b0" : "#4a4a4a",
+                    },
+                    {
+                        label: "Interest",
+                        data: snapshots.map(function (s) { return s.annualInterest; }),
+                        backgroundColor: isDark() ? "#666" : "#c5c5c5",
+                    },
+                ],
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    x: {
+                        stacked: true,
+                        title: { display: true, text: "Year", color: textColor },
+                        grid: { color: gridColor },
+                        ticks: { color: textColor },
+                    },
+                    y: {
+                        stacked: true,
+                        title: { display: true, text: "Dollars", color: textColor },
+                        grid: { color: gridColor },
+                        ticks: { color: textColor, callback: function (v) { return v >= 1000 ? "$" + Math.round(v / 1000) + "k" : "$" + v; } },
+                    },
+                },
+                plugins: {
+                    legend: { display: true, labels: { color: textColor, boxWidth: 12 } },
+                    tooltip: {
+                        callbacks: {
+                            label: function (ctx) { return ctx.dataset.label + ": " + fmt(ctx.parsed.y); },
+                        },
+                    },
+                },
+            },
+        });
+
+        select.onchange = function () {
+            drawIPSplitChart(results, gridColor, textColor);
+        };
+    }
+
+    function drawInterestBarChart(sim, gridColor, textColor) {
+        destroyChart("interestBarChart");
+        var canvas = $("interestBarChart");
+        if (!canvas) return;
 
         var tr = sim.termResults;
         if (tr.length === 0) return;
 
-        var maxInterest = 0;
-        tr.forEach(function (t) { if (t.interestPaid > maxInterest) maxInterest = t.interestPaid; });
-        if (maxInterest === 0) return;
-
-        var niceMax = Math.ceil(maxInterest / 5000) * 5000;
-        if (niceMax === 0) niceMax = 5000;
-
-        var barGroupWidth = plotW / tr.length;
-        var barWidth = Math.max(1, Math.min(barGroupWidth * 0.55, 60));
-
-        // Grid
-        ctx.strokeStyle = cssVar("--chart-line");
-        ctx.lineWidth = 1;
-        ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
-        ctx.fillStyle = cssVar("--chart-text");
-        ctx.textAlign = "right";
-        ctx.textBaseline = "middle";
-
-        for (var g = 0; g <= 4; g++) {
-            var y = pad.top + (plotH / 4) * g;
-            ctx.beginPath();
-            ctx.moveTo(pad.left, y);
-            ctx.lineTo(pad.left + plotW, y);
-            ctx.stroke();
-            var val = niceMax * (1 - g / 4);
-            ctx.fillText(fmt(val), pad.left - 6, y);
-        }
-
-        // Bars
-        tr.forEach(function (t, i) {
-            var cx = pad.left + barGroupWidth * i + barGroupWidth / 2;
-            var x = cx - barWidth / 2;
-            var bHeight = (t.interestPaid / niceMax) * plotH;
-
-            ctx.fillStyle = termColors()[i % termColors().length];
-            ctx.fillRect(x, pad.top + plotH - bHeight, barWidth, bHeight);
-
-            // Value on top
-            ctx.fillStyle = cssVar("--text-2");
-            ctx.textAlign = "center";
-            ctx.textBaseline = "bottom";
-            ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
-            ctx.fillText(fmt(t.interestPaid), cx, pad.top + plotH - bHeight - 4);
-
-            // Term label
-            ctx.fillStyle = cssVar("--text-2");
-            ctx.textBaseline = "top";
-            ctx.font = '600 10px -apple-system, system-ui, sans-serif';
-            ctx.fillText("TERM " + (i + 1), cx, pad.top + plotH + 6);
-            ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
-            ctx.fillStyle = cssVar("--text-3");
-            ctx.fillText(t.years + "yr @ " + t.rate + "%", cx, pad.top + plotH + 20);
-        });
-
-        // Y-axis label
-        ctx.save();
-        ctx.translate(14, pad.top + plotH / 2);
-        ctx.rotate(-Math.PI / 2);
-        ctx.fillStyle = cssVar("--chart-text");
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.font = '600 10px -apple-system, system-ui, sans-serif';
-        ctx.fillText("INTEREST PAID", 0, 0);
-        ctx.restore();
-    }
-
-    // --- Pie chart: total cost breakdown ---
-
-    function drawPieChart(sim) {
-        var canvas = document.getElementById("pieChart");
-        var dpr = window.devicePixelRatio || 1;
-        var rect = canvas.getBoundingClientRect();
-        canvas.width = rect.width * dpr;
-        canvas.height = rect.height * dpr;
-        var ctx = canvas.getContext("2d");
-        ctx.scale(dpr, dpr);
-
-        var W = rect.width;
-        var H = rect.height;
-        ctx.clearRect(0, 0, W, H);
-
-        var pc = pieColors();
-        var slices = [
-            { label: "Principal", value: sim.totalPrincipalPaid, color: pc[0] },
-            { label: "Interest", value: sim.totalInterest, color: pc[1] },
-            { label: "Property Tax", value: sim.totalTax, color: pc[2] },
-            { label: "Insurance", value: sim.totalInsurance, color: pc[3] },
-            { label: country === "ca" ? "Condo Fees" : "HOA", value: sim.totalHOA, color: pc[4] },
-        ];
-
-        if (sim.totalPMI > 0) {
-            slices.push({ label: sim.pmiLabel, value: sim.totalPMI, color: pc[5] });
-        }
-
-        slices = slices.filter(function (s) { return s.value > 0; });
-
-        if (slices.length === 0) return;
-
-        var total = 0;
-        slices.forEach(function (s) { total += s.value; });
-        if (total === 0) return;
-
-        var cx = W * 0.35;
-        var cy = H / 2;
-        var radius = Math.max(1, Math.min(cx - 20, cy - 15, 100));
-        var startAngle = -Math.PI / 2;
-
-        slices.forEach(function (s) {
-            var sliceAngle = (s.value / total) * 2 * Math.PI;
-            ctx.beginPath();
-            ctx.moveTo(cx, cy);
-            ctx.arc(cx, cy, radius, startAngle, startAngle + sliceAngle);
-            ctx.closePath();
-            ctx.fillStyle = s.color;
-            ctx.fill();
-            startAngle += sliceAngle;
-        });
-
-        // Inner circle for donut
-        ctx.beginPath();
-        ctx.arc(cx, cy, radius * 0.52, 0, Math.PI * 2);
-        ctx.fillStyle = cssVar("--bg");
-        ctx.fill();
-
-        // Center text
-        ctx.fillStyle = cssVar("--text");
-        ctx.font = '600 13px "SF Mono", "Roboto Mono", Menlo, monospace';
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.fillText(fmt(total), cx, cy - 6);
-        ctx.font = '600 9px -apple-system, system-ui, sans-serif';
-        ctx.fillStyle = cssVar("--chart-text");
-        ctx.fillText("TOTAL COST", cx, cy + 8);
-
-        // Legend
-        var legendX = W * 0.65;
-        var legendY = cy - slices.length * 13;
-        ctx.textAlign = "left";
-        ctx.textBaseline = "middle";
-        ctx.font = '600 10px -apple-system, system-ui, sans-serif';
-
-        slices.forEach(function (s, i) {
-            var ly = legendY + i * 26;
-            ctx.fillStyle = s.color;
-            ctx.fillRect(legendX, ly - 5, 12, 10);
-
-            ctx.fillStyle = cssVar("--text");
-            ctx.fillText(s.label, legendX + 18, ly);
-
-            ctx.fillStyle = cssVar("--chart-text");
-            ctx.font = '10px "SF Mono", "Roboto Mono", Menlo, monospace';
-            ctx.fillText(fmt(s.value) + " (" + (s.value / total * 100).toFixed(1) + "%)", legendX + 18, ly + 13);
-            ctx.font = '600 10px -apple-system, system-ui, sans-serif';
+        var tc = getTermColors();
+        chartInstances["interestBarChart"] = new Chart(canvas, {
+            type: "bar",
+            data: {
+                labels: tr.map(function (t, i) { return "Term " + (i + 1); }),
+                datasets: [{
+                    label: "Interest Paid",
+                    data: tr.map(function (t) { return t.interestPaid; }),
+                    backgroundColor: tr.map(function (t, i) { return tc[i % tc.length]; }),
+                    borderWidth: 0,
+                }],
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    x: { grid: { display: false }, ticks: { color: textColor } },
+                    y: {
+                        grid: { color: gridColor },
+                        ticks: { color: textColor, callback: function (v) { return fmt(v); } },
+                        title: { display: true, text: "Interest Paid", color: textColor },
+                    },
+                },
+                plugins: {
+                    legend: { display: false },
+                    tooltip: {
+                        callbacks: {
+                            title: function (items) {
+                                var i = items[0].dataIndex;
+                                return "Term " + (i + 1) + " &mdash; " + tr[i].years + "yr @ " + tr[i].rate + "%";
+                            },
+                            label: function (ctx) { return fmt(ctx.parsed.y); },
+                        },
+                    },
+                },
+            },
         });
     }
 
-    // --- Amortization schedule ---
+    // ===== CHART TABS =====
+
+    $("charts-container").querySelectorAll(".chart-tab").forEach(function (tab) {
+        tab.addEventListener("click", function () {
+            $("charts-container").querySelectorAll(".chart-tab").forEach(function (t) { t.classList.remove("active"); });
+            tab.classList.add("active");
+            $("charts-container").querySelectorAll(".chart-panel").forEach(function (p) { p.classList.remove("visible"); });
+            var panel = $("panel-" + tab.dataset.chart);
+            if (panel) panel.classList.add("visible");
+        });
+    });
+
+    // ===== AMORTIZATION SCHEDULE =====
 
     function renderSchedule(sim) {
-        scheduleSection.style.display = "block";
+        $("schedule-section").style.display = "block";
         var rows = sim.schedule;
+        var ppy = frequencyConfig[paymentFrequency].ppy;
+        var startYear = parseInt($("start-year").value, 10) || 2026;
 
         if (scheduleMode === "annual") {
             var byYear = {};
             rows.forEach(function (r) {
-                var key = r.year;
-                if (!byYear[key]) byYear[key] = { year: key, termIndex: r.termIndex, payment: 0, principal: 0, interest: 0, tax: 0, insurance: 0, hoa: 0, pmi: 0, balance: 0 };
+                var key = r.yearFromStart;
+                if (!byYear[key]) byYear[key] = { yearFromStart: key, year: r.year, termIndex: r.termIndex, payment: 0, principal: 0, interest: 0, balance: 0 };
                 byYear[key].payment += r.payment;
                 byYear[key].principal += r.principal;
                 byYear[key].interest += r.interest;
-                byYear[key].tax += r.tax;
-                byYear[key].insurance += r.insurance;
-                byYear[key].hoa += r.hoa;
-                byYear[key].pmi += r.pmi;
                 byYear[key].balance = r.balance;
             });
             var yearRows = Object.keys(byYear).sort(function (a, b) { return a - b; }).map(function (k) { return byYear[k]; });
 
-            scheduleTableHead.innerHTML = "<tr><th>Year</th><th>Payment</th><th>Principal</th><th>Interest</th>" +
-                (sim.totalPMI > 0 ? "<th>" + sim.pmiLabel + "</th>" : "") +
-                "<th>Tax</th><th>Ins.</th><th>" + (country === "ca" ? "Condo" : "HOA") + "</th><th>Balance</th></tr>";
+            $("schedule-table").querySelector("thead").innerHTML =
+                "<tr><th>Year</th><th>Payment</th><th>Principal</th><th>Interest</th><th>Balance</th></tr>";
 
             var html = "";
             var prevTerm = yearRows.length > 0 ? yearRows[0].termIndex : -1;
@@ -968,127 +1341,253 @@
                     "<td>" + fmt(r.payment) + "</td>" +
                     "<td>" + fmt(r.principal) + "</td>" +
                     "<td>" + fmt(r.interest) + "</td>" +
-                    (sim.totalPMI > 0 ? "<td>" + fmt(r.pmi) + "</td>" : "") +
-                    "<td>" + fmt(r.tax) + "</td>" +
-                    "<td>" + fmt(r.insurance) + "</td>" +
-                    "<td>" + fmt(r.hoa) + "</td>" +
                     "<td>" + fmt(r.balance) + "</td>" +
                     "</tr>";
             });
-            scheduleTableBody.innerHTML = html;
+            $("schedule-table").querySelector("tbody").innerHTML = html;
         } else {
-            scheduleTableHead.innerHTML = "<tr><th>Date</th><th>Payment</th><th>Principal</th><th>Interest</th>" +
-                (sim.totalPMI > 0 ? "<th>" + sim.pmiLabel + "</th>" : "") +
-                "<th>Balance</th></tr>";
+            // Detail view
+            $("schedule-table").querySelector("thead").innerHTML =
+                "<tr><th>Period</th><th>Payment</th><th>Principal</th><th>Interest</th><th>Balance</th></tr>";
 
             var html = "";
             var prevTerm = rows.length > 0 ? rows[0].termIndex : -1;
             rows.forEach(function (r) {
                 var cls = r.termIndex !== prevTerm ? ' class="term-boundary"' : "";
                 prevTerm = r.termIndex;
+                var label = paymentFrequency === "monthly"
+                    ? monthNames[r.month] + " " + r.year
+                    : "Y" + (r.yearFromStart + 1) + " P" + (r.periodInYear + 1);
                 html += "<tr" + cls + ">" +
-                    "<td>" + monthNames[r.month] + " " + r.year + "</td>" +
+                    "<td>" + label + "</td>" +
                     "<td>" + fmt(r.payment) + "</td>" +
                     "<td>" + fmt(r.principal) + "</td>" +
                     "<td>" + fmt(r.interest) + "</td>" +
-                    (sim.totalPMI > 0 ? "<td>" + fmt(r.pmi) + "</td>" : "") +
                     "<td>" + fmt(r.balance) + "</td>" +
                     "</tr>";
             });
-            scheduleTableBody.innerHTML = html;
+            $("schedule-table").querySelector("tbody").innerHTML = html;
         }
     }
 
-    // Schedule toggle
-    btnMonthly.addEventListener("click", function () {
-        scheduleMode = "monthly";
-        btnMonthly.classList.add("active");
-        btnAnnual.classList.remove("active");
-        if (lastSimResult) renderSchedule(lastSimResult);
+    $("btn-detail").addEventListener("click", function () {
+        scheduleMode = "detail";
+        $("btn-detail").classList.add("active");
+        $("btn-annual").classList.remove("active");
+        if (lastSimResults) renderSchedule(lastSimResults.base);
     });
 
-    btnAnnual.addEventListener("click", function () {
+    $("btn-annual").addEventListener("click", function () {
         scheduleMode = "annual";
-        btnAnnual.classList.add("active");
-        btnMonthly.classList.remove("active");
-        if (lastSimResult) renderSchedule(lastSimResult);
+        $("btn-annual").classList.add("active");
+        $("btn-detail").classList.remove("active");
+        if (lastSimResults) renderSchedule(lastSimResults.base);
     });
 
-    // --- Event bindings ---
+    // ===== EXPORT/SHARE =====
 
-    [amortInput, paymentIncreaseInput, lumpSumAnnualInput, lumpSumTermInput,
-     propertyTaxInput, homeInsuranceInput, hoaInput, pmiInput, startYearInput,
-     rateOptimisticInput, ratePessimisticInput].forEach(function (el) {
-        el.addEventListener("input", render);
+    function base64Encode(str) {
+        return btoa(unescape(encodeURIComponent(str)));
+    }
+
+    function base64Decode(str) {
+        try { return decodeURIComponent(escape(atob(str))); } catch (e) { return null; }
+    }
+
+    $("btn-share").addEventListener("click", function () {
+        try {
+            var state = {
+                c: country,
+                hv: $("home-value").value,
+                dp: $("down-payment").value,
+                am: $("amortization").value,
+                pi: $("payment-increase").value,
+                la: $("lump-sum-annual").value,
+                lt: $("lump-sum-term").value,
+                pf: paymentFrequency,
+                ftb: firstTimeBuyer,
+                nb: newBuild,
+                t: terms,
+                sc: scenarios.filter(function (s) { return s.id !== "base"; }),
+            };
+            var encoded = base64Encode(JSON.stringify(state));
+            var url = window.location.pathname + "?s=" + encodeURIComponent(encoded);
+            navigator.clipboard.writeText(window.location.origin + url).then(function () {
+                $("btn-share").textContent = "Copied!";
+                setTimeout(function () { $("btn-share").textContent = "Copy shareable link"; }, 2000);
+            });
+        } catch (e) {}
     });
 
-    startMonthInput.addEventListener("change", render);
+    $("btn-csv").addEventListener("click", function () {
+        if (!lastSimResults) return;
+        var lines = ["Scenario,Year,Period,Payment,Principal,Interest,Balance"];
+        var ppy = frequencyConfig[paymentFrequency].ppy;
+
+        function addScenarioRows(label, sim) {
+            sim.schedule.forEach(function (r) {
+                lines.push(
+                    label + "," +
+                    r.year + "," +
+                    (r.periodInYear + 1) + "," +
+                    r.payment.toFixed(2) + "," +
+                    r.principal.toFixed(2) + "," +
+                    r.interest.toFixed(2) + "," +
+                    r.balance.toFixed(2)
+                );
+            });
+        }
+
+        addScenarioRows("Base", lastSimResults.base);
+        Object.keys(lastSimResults.scenarios).forEach(function (id) {
+            var sc = scenarios.find(function (s) { return s.id === id; });
+            if (sc) addScenarioRows(sc.label, lastSimResults.scenarios[id]);
+        });
+
+        var csv = lines.join("\n");
+        var blob = new Blob([csv], { type: "text/csv" });
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement("a");
+        a.href = url;
+        a.download = "mortgage-amortization.csv";
+        a.click();
+        URL.revokeObjectURL(url);
+    });
+
+    // ===== URL STATE =====
+
+    function loadUrlState() {
+        try {
+            var params = new URLSearchParams(window.location.search);
+            var encoded = params.get("s");
+            if (!encoded) return null;
+            var json = base64Decode(decodeURIComponent(encoded));
+            if (!json) return null;
+            var state = JSON.parse(json);
+            return {
+                v: 2,
+                country: state.c || "ca",
+                homeValue: state.hv,
+                downPayment: state.dp,
+                amortization: state.am,
+                paymentIncrease: state.pi,
+                lumpSumAnnual: state.la,
+                lumpSumTerm: state.lt,
+                paymentFrequency: state.pf || "monthly",
+                firstTimeBuyer: !!state.ftb,
+                newBuild: !!state.nb,
+                terms: state.t || [],
+                scenarios: [{ id: "base", label: "Base", locked: true, color: baseColor, visible: true }].concat(
+                    (state.sc || []).map(function (s, i) {
+                        s.visible = true;
+                        return s;
+                    })
+                ),
+            };
+        } catch (e) { return null; }
+    }
+
+    // ===== EVENT BINDINGS =====
+
+    [$("amortization"), $("payment-increase"), $("lump-sum-annual"), $("lump-sum-term"), $("start-year")].forEach(function (el) {
+        el.addEventListener("input", function () { syncLoan(); render(); });
+    });
+
+    $("payment-frequency").addEventListener("change", function () {
+        paymentFrequency = this.value;
+        render();
+    });
+
+    $("first-time-buyer").addEventListener("change", function () {
+        firstTimeBuyer = this.checked;
+        syncLoan();
+        render();
+    });
+
+    $("new-build").addEventListener("change", function () {
+        newBuild = this.checked;
+        syncLoan();
+        render();
+    });
+
+    $("start-month").addEventListener("change", render);
 
     var resizeTimer;
     window.addEventListener("resize", function () {
         clearTimeout(resizeTimer);
-        resizeTimer = setTimeout(function () { if (lastSimResult) render(); }, 150);
+        resizeTimer = setTimeout(function () { if (lastSimResults) render(); }, 150);
     });
 
-    // Re-render charts when theme changes (canvas doesn't respond to CSS)
+    // Re-render charts when theme changes
     new MutationObserver(function () {
-        if (lastSimResult) {
-            drawInterestChart(lastSimResult);
-            drawPieChart(lastSimResult);
-        }
+        if (lastSimResults) render();
     }).observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
 
-    // --- Init ---
+    // ===== INIT =====
 
+    var urlState = loadUrlState();
     var saved = loadState();
-    if (saved && applyState(saved)) {
-        // Restored from localStorage
+    var migrated = migrateState(saved);
+
+    if (urlState) {
+        applyState(urlState);
+    } else if (migrated && applyState(migrated)) {
+        // Restored
     } else {
-        terms = countryConfig.ca.defaultTerms.map(function (t) { return { years: t.years, rate: t.rate, schedule: t.schedule }; });
+        terms = countryConfig.ca.defaultTerms.map(function (t) { return { years: t.years, rate: t.rate }; });
+        initScenarios();
     }
+
+    // Ensure base scenario exists
+    if (!scenarios.find(function (s) { return s.id === "base"; })) {
+        scenarios.unshift({ id: "base", label: "Base", locked: true, color: baseColor, visible: true });
+    }
+
+    $("payment-frequency").value = paymentFrequency;
+    $("first-time-buyer").checked = firstTimeBuyer;
+    $("new-build").checked = newBuild;
+
     syncLoan();
     renderTerms();
+    renderScenarioChips();
     renderCountryInfo();
     loadCollapsedState();
     render();
 
-    // Clear all button
-    btnClear.addEventListener("click", function () {
+    // Clear button
+    $("btn-clear").addEventListener("click", function () {
         clearState();
-        try { localStorage.removeItem(LS_KEY + "-collapsed"); } catch (e) {}
         country = "ca";
-        btnCA.classList.add("active");
-        btnUS.classList.remove("active");
+        $("btn-ca").classList.add("active");
+        $("btn-us").classList.remove("active");
         var cfg = countryConfig.ca;
-        pmiLabel.textContent = cfg.insuranceLabel;
-        hoaLabel.textContent = cfg.hoaLabel;
-        propertyTaxLabel.textContent = cfg.taxLabel;
-        amortInput.max = cfg.maxAmort;
+        $("amortization").max = cfg.maxAmort;
 
-        homeValueInput.value = 500000;
-        downPaymentInput.value = 100000;
-        amortInput.value = cfg.defaultAmort;
-        paymentIncreaseInput.value = 0;
-        lumpSumAnnualInput.value = 0;
-        lumpSumTermInput.value = 0;
-        propertyTaxInput.value = 3500;
-        homeInsuranceInput.value = 1200;
-        hoaInput.value = 0;
-        pmiInput.value = 0;
-        startMonthInput.value = 5;
-        startYearInput.value = 2026;
-        rateOptimisticInput.value = -1;
-        ratePessimisticInput.value = 2;
+        $("home-value").value = 500000;
+        $("down-payment").value = 100000;
+        $("amortization").value = cfg.defaultAmort;
+        $("payment-increase").value = 0;
+        $("lump-sum-annual").value = 0;
+        $("lump-sum-term").value = 0;
+        $("start-month").value = 5;
+        $("start-year").value = 2026;
+        $("payment-frequency").value = "monthly";
+        paymentFrequency = "monthly";
+        firstTimeBuyer = false;
+        newBuild = false;
+        $("first-time-buyer").checked = false;
+        $("new-build").checked = false;
 
-        terms = cfg.defaultTerms.map(function (t) { return { years: t.years, rate: t.rate, schedule: t.schedule }; });
+        terms = cfg.defaultTerms.map(function (t) { return { years: t.years, rate: t.rate }; });
+        initScenarios();
 
-        // Reset collapsibles to collapsed
         Object.keys(collapsibles).forEach(function (key) {
             collapsibles[key].body.classList.add("collapsed");
             collapsibles[key].arrow.classList.remove("open");
         });
 
         renderTerms();
+        renderScenarioChips();
         syncLoan();
         renderCountryInfo();
         render();

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -735,9 +735,11 @@
             var termInterest = 0;
 
             for (var p = 0; p < termPeriods && balance > 0.01; p++) {
-                if (p > 0 && p % ppy === 0) {
+                paymentsThisYear++;
+
+                // Year boundary: after ppy payments, emit snapshot and apply increase
+                if (paymentsThisYear === ppy) {
                     payment += annualIncrease;
-                    // Emit annual snapshot at year boundary
                     currentPaymentYear++;
                     annualSnapshots.push({
                         year: currentPaymentYear,
@@ -750,6 +752,7 @@
                     });
                     yearPrincipal = 0;
                     yearInterest = 0;
+                    paymentsThisYear = 0;
                 }
 
                 var interestPortion = balance * r;
@@ -762,7 +765,6 @@
                 cumulativeInterest += interestPortion;
                 yearPrincipal += principalPortion;
                 yearInterest += interestPortion;
-                paymentsThisYear++;
 
                 var periodInYear = globalPeriod % ppy;
                 var yearFromStart = Math.floor(globalPeriod / ppy);
@@ -785,7 +787,11 @@
 
                 globalPeriod++;
 
-                if (lumpAnnual > 0 && paymentsThisYear === ppy && balance > 0.01) {
+                // Lump sum: apply after the last payment of each year
+                // (paymentsThisYear was already reset at year boundary, so
+                // this checks if we just hit ppy by checking before the reset)
+                if (lumpAnnual > 0 && paymentsThisYear === 0 && p > 0 && balance > 0.01) {
+                    // paymentsThisYear === 0 means we just reset at year boundary
                     var lumpApply = Math.min(lumpAnnual, balance);
                     balance -= lumpApply;
                     termPrincipal += lumpApply;
@@ -803,11 +809,25 @@
             remainingAmort -= term.years;
             if (remainingAmort < 1) remainingAmort = 1;
 
+            // Compute remaining time in years + months from remaining amortization
             var remainingYears = 0;
             var remainingMonths = 0;
             if (balance > 0.01) {
-                remainingYears = Math.max(0, remainingAmort);
-                remainingMonths = 0;
+                // remainingAmort is in whole years (truncated). Use the original
+                // amortization minus elapsed years to get a more precise fraction.
+                var elapsedYears = 0;
+                for (var ei = 0; ei <= ti; ei++) {
+                    elapsedYears += termDefs[ei].years;
+                }
+                var totalRemaining = amortYears - elapsedYears;
+                if (totalRemaining > 0) {
+                    remainingYears = Math.floor(totalRemaining);
+                    remainingMonths = Math.round((totalRemaining - remainingYears) * 12);
+                    if (remainingMonths >= 12) {
+                        remainingYears++;
+                        remainingMonths -= 12;
+                    }
+                }
             }
 
             termResults.push({

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -1062,6 +1062,9 @@
             };
         });
 
+        // Store base scenario ID for tooltip delta calculation
+        var baseId = scenarios.find(function (s) { return s.id === "base"; }) ? "base" : null;
+
         chartInstances[canvasId] = new Chart(canvas, {
             type: "line",
             data: { datasets: datasets },
@@ -1090,6 +1093,24 @@
                     legend: { display: false },
                     tooltip: {
                         callbacks: {
+                            afterBody: function (items) {
+                                if (!baseId || items.length <= 1) return [];
+                                var baseVal = null;
+                                items.forEach(function (item) {
+                                    var sc = visibleScenarios[item.datasetIndex];
+                                    if (sc && sc.id === baseId) baseVal = item.parsed.y;
+                                });
+                                if (baseVal === null) return [];
+                                var lines = [];
+                                items.forEach(function (item) {
+                                    var sc = visibleScenarios[item.datasetIndex];
+                                    if (!sc || sc.id === baseId) return;
+                                    var delta = item.parsed.y - baseVal;
+                                    var sign = delta >= 0 ? "+" : "";
+                                    lines.push(sc.label + " " + sign + fmt(delta) + " vs Base");
+                                });
+                                return lines;
+                            },
                             label: function (ctx) { return ctx.dataset.label + ": " + fmt(ctx.parsed.y); },
                         },
                     },
@@ -1143,6 +1164,8 @@
             };
         });
 
+        var baseId = scenarios.find(function (s) { return s.id === "base"; }) ? "base" : null;
+
         chartInstances["paymentChart"] = new Chart(canvas, {
             type: "line",
             data: { datasets: datasets },
@@ -1168,6 +1191,24 @@
                     legend: { display: false },
                     tooltip: {
                         callbacks: {
+                            afterBody: function (items) {
+                                if (!baseId || items.length <= 1) return [];
+                                var baseVal = null;
+                                items.forEach(function (item) {
+                                    var sc = visibleScenarios[item.datasetIndex];
+                                    if (sc && sc.id === baseId) baseVal = item.parsed.y;
+                                });
+                                if (baseVal === null) return [];
+                                var lines = [];
+                                items.forEach(function (item) {
+                                    var sc = visibleScenarios[item.datasetIndex];
+                                    if (!sc || sc.id === baseId) return;
+                                    var delta = item.parsed.y - baseVal;
+                                    var sign = delta >= 0 ? "+" : "";
+                                    lines.push(sc.label + " " + sign + fmtFull(delta) + " vs Base");
+                                });
+                                return lines;
+                            },
                             label: function (ctx) { return ctx.dataset.label + ": " + fmtFull(ctx.parsed.y) + freqSuffix(); },
                         },
                     },
@@ -1452,6 +1493,27 @@
         a.download = "mortgage-amortization.csv";
         a.click();
         URL.revokeObjectURL(url);
+    });
+
+    $("btn-png").addEventListener("click", function () {
+        // Export the currently visible chart panel as PNG
+        var panels = ["balance", "cumulative", "payment", "ip"];
+        var visibleCanvas = null;
+        for (var i = 0; i < panels.length; i++) {
+            var panel = $("panel-" + panels[i]);
+            if (panel && panel.classList.contains("visible")) {
+                visibleCanvas = panel.querySelector("canvas");
+                break;
+            }
+        }
+        if (!visibleCanvas) return;
+        var chartInstance = Chart.getChart(visibleCanvas);
+        if (!chartInstance) return;
+        var dataUrl = chartInstance.toBase64Image("image/png", 1);
+        var a = document.createElement("a");
+        a.href = dataUrl;
+        a.download = "mortgage-chart.png";
+        a.click();
     });
 
     // ===== URL STATE =====

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -632,6 +632,8 @@
             var r = effectivePeriodRate(term.rate, freq, compounding);
             var termPeriods = term.years * ppy;
             var basePayment = calcPeriodicPayment(balance, term.rate, remainingAmort, freq, compounding);
+            // Fix initial snapshot payment now that we know the first term's payment
+            if (ti === 0) annualSnapshots[0].payment = basePayment;
             var payment = basePayment;
             var paymentsThisYear = 0;
             var termPrincipal = 0;
@@ -806,9 +808,11 @@
         var html =
             '<div class="result-summary">' +
             '<div class="summary-card"><div class="label">Total Paid</div><div class="value">' + fmt(sim.totalPaid) + '</div></div>' +
+            '<div class="summary-card"><div class="label">Total Principal</div><div class="value">' + fmt(sim.totalPrincipalPaid) + '</div></div>' +
             '<div class="summary-card"><div class="label">Total Interest</div><div class="value">' + fmt(sim.totalInterest) + '</div></div>' +
-            '<div class="summary-card accent"><div class="label">Interest / Payments</div><div class="value">' + fmtPct(sim.totalPaid > 0 ? sim.totalInterest / sim.totalPaid * 100 : 0) + '</div></div>' +
-            '</div>';
+            '</div>' +
+            '<div class="result-summary" style="margin-bottom:1.25rem">' +
+            '<div class="summary-card accent"><div class="label">Interest / Payments</div><div class="value">' + fmtPct(sim.totalPaid > 0 ? sim.totalInterest / sim.totalPaid * 100 : 0) + '</div></div>';
 
         // CMHC premium card
         var hv = parseFloat($("home-value").value) || 0;
@@ -829,7 +833,9 @@
         sim.termResults.forEach(function (tr, i) {
             var remainingText = "";
             if (tr.balanceAtEnd > 0.01) {
-                remainingText = '<div class="term-remaining">' + tr.remainingYears + ' yr remaining on amortization</div>';
+                var ry = tr.remainingYears;
+                var rm = tr.remainingMonths;
+                remainingText = '<div class="term-remaining">' + ry + (ry === 1 ? ' yr' : ' yrs') + (rm > 0 ? ' ' + rm + (rm === 1 ? ' mo' : ' mos') : '') + ' remaining on amortization</div>';
             }
             html +=
                 '<div class="term-result">' +
@@ -949,13 +955,17 @@
             var interestDelta = scSim.totalInterest - sim.totalInterest;
             var baseMonths = sim.totalPeriods;
             var scMonths = scSim.totalPeriods;
-            var monthDelta = scMonths - baseMonths;
+            // Convert payment periods to calendar months
+            var ppy = frequencyConfig[paymentFrequency].ppy;
+            var baseCalMonths = Math.round(baseMonths * 12 / ppy);
+            var scCalMonths = Math.round(scMonths * 12 / ppy);
+            var monthDelta = scCalMonths - baseCalMonths;
             var balanceAtFirstRenewal = sim.termResults.length > 0 ? sim.termResults[0].balanceAtEnd : 0;
             var scBalanceAtFirstRenewal = scSim.termResults.length > 0 ? scSim.termResults[0].balanceAtEnd : 0;
             var balanceDelta = scBalanceAtFirstRenewal - balanceAtFirstRenewal;
 
             var interestClass = interestDelta < 0 ? "negative" : "positive";
-            var paidOffText = monthDelta < 0 ? Math.abs(monthDelta) + " periods early" : monthDelta > 0 ? monthDelta + " periods late" : "same";
+            var paidOffText = monthDelta < 0 ? Math.abs(monthDelta) + " mo early" : monthDelta > 0 ? monthDelta + " mo late" : "same";
             var balanceClass = balanceDelta < 0 ? "negative" : balanceDelta > 0 ? "positive" : "";
 
             html +=
@@ -1155,7 +1165,7 @@
                 borderDash: [4, 4],
                 label: {
                     display: true,
-                    content: tb.label,
+                    content: tb.label + " (" + tb.rate + "%)",
                     position: "start",
                     font: { size: 10 },
                     backgroundColor: "transparent",
@@ -1241,19 +1251,25 @@
         var labels = snapshots.map(function (s) { return s.year; });
 
         chartInstances["ipSplitChart"] = new Chart(canvas, {
-            type: "bar",
+            type: "line",
             data: {
                 labels: labels,
                 datasets: [
                     {
                         label: "Principal",
                         data: snapshots.map(function (s) { return s.annualPrincipal; }),
-                        backgroundColor: isDark() ? "#b0b0b0" : "#4a4a4a",
+                        backgroundColor: isDark() ? "rgba(176,176,176,0.5)" : "rgba(74,74,74,0.5)",
+                        borderColor: isDark() ? "#b0b0b0" : "#4a4a4a",
+                        borderWidth: 1,
+                        fill: true,
                     },
                     {
                         label: "Interest",
                         data: snapshots.map(function (s) { return s.annualInterest; }),
-                        backgroundColor: isDark() ? "#666" : "#c5c5c5",
+                        backgroundColor: isDark() ? "rgba(102,102,102,0.5)" : "rgba(197,197,197,0.5)",
+                        borderColor: isDark() ? "#666" : "#c5c5c5",
+                        borderWidth: 1,
+                        fill: true,
                     },
                 ],
             },
@@ -1462,15 +1478,14 @@
 
     $("btn-csv").addEventListener("click", function () {
         if (!lastSimResults) return;
-        var lines = ["Scenario,Year,Period,Payment,Principal,Interest,Balance"];
-        var ppy = frequencyConfig[paymentFrequency].ppy;
+        var lines = ["Year,Month,Scenario,Payment,Principal,Interest,Balance"];
 
         function addScenarioRows(label, sim) {
             sim.schedule.forEach(function (r) {
                 lines.push(
-                    label + "," +
                     r.year + "," +
-                    (r.periodInYear + 1) + "," +
+                    (r.month + 1) + "," +
+                    '"' + label + '",' +
                     r.payment.toFixed(2) + "," +
                     r.principal.toFixed(2) + "," +
                     r.interest.toFixed(2) + "," +

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -1,5 +1,11 @@
 (function () {
     // ===== CONSTANTS =====
+    //
+    // SCOPE: Mortgage principal + interest only.
+    // Property tax, home insurance, HOA/condo fees, and PMI are explicitly
+    // out of scope. Canada gets auto-calculated CMHC (one-time premium).
+    // See: https://seriousben.com/tools/multi-term-mortgage-calculator/
+    //
     var LS_KEY = "mortgage-calc-v2";
     var LS_COLLAPSED_KEY = "mortgage-calc-v2-collapsed";
     var monthNames = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
@@ -86,12 +92,38 @@
         return isDark() ? termColorsDark : termColorsLight;
     }
 
+    // Derive the periodic interest rate from the quoted annual rate.
+    //
+    // Canada (fixed-rate): The Interest Act mandates semi-annual compounding.
+    //   effectiveAnnualRate = (1 + nominalRate/2)^2 - 1
+    //   periodicRate        = (1 + effectiveAnnualRate)^(1/ppy) - 1
+    // which simplifies to:  (1 + semiRate)^(2/ppy) - 1
+    //
+    //   Monthly: (1 + rate/2)^(1/6) - 1   (NOT rate/12)
+    //   At 5%, monthly rate = 0.41246% (US rate/12 gives 0.41667%, ~$9/mo wrong)
+    //
+    // Sources:
+    //   - Canada.ca FCAC: https://www.canada.ca/en/financial-consumer-agency/services/mortgages/interest-on-mortgages.html
+    //   - WOWA.ca: https://wowa.ca/how-is-mortgage-interest-calculated
+    //   - First Foundation: https://www.firstfoundation.ca/mortgage-glossary/compound-period/
+    //
+    //   Verified against Canada.ca unit test values ($300k, 25yr):
+    //     2.5% -> $1,343.90,  4.0% -> $1,578.06,
+    //     5.0% -> $1,744.81,  5.2% -> $1,779.13
+    //
+    // US: Simple monthly compounding. periodicRate = annualRate / n.
+    //
+    // Note: Variable-rate mortgages may compound monthly (lender-dependent).
+    // If a per-term rate-type toggle is added, branch here: semi-annual for
+    // fixed, monthly for variable.
+    //
     function effectivePeriodRate(annualRate, frequency, compounding) {
         var ppy = frequencyConfig[frequency].ppy;
         if (compounding === "semi-annual") {
             var semiRate = annualRate / 100 / 2;
             return Math.pow(1 + semiRate, 2 / ppy) - 1;
         }
+        // US: rate / payments-per-year
         return annualRate / 100 / ppy;
     }
 
@@ -103,6 +135,19 @@
         return principal * (r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1);
     }
 
+    // Convert monthly payment to the periodic payment for a given frequency.
+    //
+    // Non-accelerated frequencies produce the same total annual payment as monthly:
+    //   semi-monthly: monthly / 2          (24 payments = 12 monthly payments)
+    //   bi-weekly:    (monthly * 12) / 26  (26 payments = 12 monthly payments)
+    //   weekly:       (monthly * 12) / 52  (52 payments = 12 monthly payments)
+    //
+    // Accelerated frequencies keep the "half/quarter of monthly" amount but
+    // collect more frequently, producing ~1 extra monthly payment per year:
+    //   accelerated bi-weekly: monthly / 2  (26 payments = 13 monthly payments/year)
+    //   accelerated weekly:   monthly / 4  (52 payments = 13 monthly payments/year)
+    //
+    // This typically shaves 2-4 years off a 25-year amortization.
     function calcPeriodicPayment(principal, annualRate, remainingAmortYears, frequency, compounding) {
         var monthlyPmt = calcMonthlyPayment(principal, annualRate, remainingAmortYears, compounding);
         switch (frequency) {
@@ -116,10 +161,27 @@
         }
     }
 
-    // ===== CMHC =====
+    // ===== CMHC (Canada Mortgage and Housing Corporation) =====
+    //
+    // CMHC default insurance is a ONE-TIME premium added to the mortgage
+    // principal, not an annual charge. This is fundamentally different from
+    // US PMI (ongoing monthly cost), which is out of scope for this calculator.
+    //
+    // The premium is a percentage of the LOAN AMOUNT (not purchase price).
+    // Example: $500k home, 5% down -> mortgage $475k -> 4% premium = $19k
+    //   -> starting principal = $494,000 (premium amortized as part of the loan)
+    //
+    // Sources:
+    //   - WOWA.ca: https://wowa.ca/calculators/cmhc-insurance
+    //   - Ratehub.ca: https://www.ratehub.ca/cmhc-mortgage-insurance
 
     function cmhcRate(downPct) {
-        if (downPct < 5) return 4.0;
+        // Premium schedule (percentage of mortgage amount):
+        //   5.00% -  9.99% down -> 4.00%
+        //  10.00% - 14.99% down -> 3.10%
+        //  15.00% - 19.99% down -> 2.80%
+        //  >= 20%                -> 0% (no insurance required)
+        if (downPct < 5) return 4.0;   // edge case: below minimum down payment
         if (downPct < 10) return 4.0;
         if (downPct < 15) return 3.1;
         if (downPct < 20) return 2.8;
@@ -130,6 +192,15 @@
         if (downPct >= 20) return 0;
         return loanAmount * cmhcRate(downPct) / 100;
     }
+
+    // CMHC eligibility rules (effective December 15, 2024):
+    //   - Unavailable if purchase price >= $1,500,000
+    //   - Max 25yr amortization, UNLESS first-time buyer or new build (then 30yr)
+    //   - Never available above 30yr amortization
+    //
+    // Sources:
+    //   - Canada.ca FCAC: https://www.canada.ca/en/financial-consumer-agency/services/mortgages/mortgage-terms-amortization.html
+    //   - Canada.ca Finance: https://www.canada.ca/en/department-finance/news/2024/09/government-announces-boldest-mortgage-reforms-in-decades-to-unlock-homeownership-for-more-canadians.html
 
     function getCmhcWarnings(homeValue, downPct, amortYears) {
         var warnings = [];
@@ -216,6 +287,8 @@
         } catch (e) { return null; }
     }
 
+    // Migrate v1 localStorage (hard-coded Optimistic/Pessimistic offsets)
+    // to v2 scenario manager format. Preserves existing user data on upgrade.
     function migrateState(old) {
         if (!old) return null;
         if (old.v === 2) return old;
@@ -237,6 +310,7 @@
             terms: (old.terms || []).map(function (t) { return { years: t.years, rate: t.rate }; }),
             scenarios: [{ id: "base", label: "Base", locked: true, color: baseColor, visible: true }],
         };
+        // Convert old Optimistic/Pessimistic offsets to named scenarios
         var optOffset = parseFloat(old.rateOptimistic) || 0;
         var pessOffset = parseFloat(old.ratePessimistic) || 0;
         if (optOffset !== 0) {
@@ -430,6 +504,14 @@
     });
 
     // ===== SCENARIO MANAGER =====
+    //
+    // Replaces the old hard-coded Optimistic/Pessimistic offset fields.
+    // Supports up to 5 named scenarios with two modes:
+    //   offset — single +/- shift applied to all term rates
+    //   custom — independent rate per term
+    //
+    // Base scenario is always locked to the main term inputs.
+    // Colour-coded chips double as chart legend toggles.
 
     function initScenarios() {
         scenarios = [
@@ -610,6 +692,19 @@
     });
 
     // ===== SIMULATION =====
+    //
+    // Core amortization engine. Takes a set of term definitions and produces:
+    //   - Per-period schedule (payment, principal, interest, balance)
+    //   - Annual snapshots for charts (balance, cumulative interest, I vs P split)
+    //   - Per-term summary (balance at end, cumulative interest, remaining amort)
+    //
+    // Prepayments:
+    //   - Annual increase: added to payment at each year boundary within a term
+    //   - Lump sum / year: applied after the last payment of each year
+    //   - Lump sum at renewal: applied at the end of each term
+    //
+    // All scenarios share the same principal, amortization, and prepayments.
+    // Only term rates differ between scenarios.
 
     function simulateMortgage(principal, amortYears, termDefs, freq, annualIncrease, lumpAnnual, lumpTerm, startMonth, startYear) {
         var balance = principal;
@@ -983,6 +1078,20 @@
     }
 
     // ===== CHARTS =====
+    //
+    // Four multi-scenario charts driven by the amortization data:
+    //   A — Outstanding Balance Over Time (area chart, one line per scenario)
+    //   B — Cumulative Interest Paid Over Time (line chart)
+    //   C — Monthly Payment Over Time (step chart, steps at term renewals)
+    //   D — Annual Interest vs Principal Split (stacked area, per-scenario selector)
+    //
+    // Plus: Interest Paid Per Term bar chart.
+    //
+    // All charts use Chart.js with the annotation plugin for vertical dashed
+    // lines at term renewal boundaries, labelled with term number and rate.
+    //
+    // Tooltips show delta-vs-base for non-base scenarios.
+    // Colour-coded scenario chips toggle line visibility across all charts.
 
     function renderCharts(results) {
         var container = $("charts-container");

--- a/static/tools/multi-term-mortgage-calculator/style.css
+++ b/static/tools/multi-term-mortgage-calculator/style.css
@@ -171,7 +171,6 @@ body {
     color: var(--text);
 }
 
-/* Header actions */
 .header-actions {
     display: flex;
     align-items: center;
@@ -199,7 +198,6 @@ body {
 }
 
 .theme-icon { display: none; }
-:root[data-theme-mode="auto"], :root:not([data-theme-mode]) { }
 :root[data-theme-mode="auto"] .theme-icon-auto,
 :root:not([data-theme-mode]) .theme-icon-auto { display: inline; }
 :root[data-theme-mode="light"] .theme-icon-light { display: inline; }
@@ -340,13 +338,8 @@ body {
     letter-spacing: 0;
 }
 
-.prefix {
-    border-right: 1px solid var(--border);
-}
-
-.suffix {
-    border-left: 1px solid var(--border);
-}
+.prefix { border-right: 1px solid var(--border); }
+.suffix { border-left: 1px solid var(--border); }
 
 select {
     width: 100%;
@@ -366,12 +359,63 @@ select:focus {
     outline: none;
 }
 
-/* Scenario hint */
-.scenario-hint {
-    font-size: 0.6875rem;
-    color: var(--text-3);
+/* CMHC row */
+.cmhc-row {
+    margin-top: 0.75rem;
     margin-bottom: 0.5rem;
-    line-height: 1.45;
+}
+
+.cmhc-info {
+    font-size: 0.8125rem;
+    color: var(--text-2);
+    padding: 0.5rem 0.75rem;
+    background: var(--accent-soft);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+}
+
+.cmhc-amount {
+    font-family: var(--mono);
+    font-weight: 600;
+    color: var(--text);
+}
+
+.cmhc-eligibility {
+    margin-top: 0.5rem;
+    display: flex;
+    gap: 1.25rem;
+    flex-wrap: wrap;
+}
+
+.checkbox-label {
+    font-size: 0.8125rem;
+    color: var(--text-2);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.checkbox-label input[type="checkbox"] {
+    width: 1rem;
+    height: 1rem;
+    cursor: pointer;
+    accent-color: var(--accent);
+}
+
+.cmhc-warnings {
+    margin-top: 0.5rem;
+}
+
+.warning-text {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: #c0392b;
+    margin-bottom: 0.25rem;
+}
+
+:root[data-theme="dark"] .warning-text {
+    color: #e85555;
 }
 
 /* Collapsible sections */
@@ -400,9 +444,7 @@ select:focus {
     display: inline-block;
 }
 
-.toggle-arrow.open {
-    transform: rotate(180deg);
-}
+.toggle-arrow.open { transform: rotate(180deg); }
 
 .section-body {
     overflow: hidden;
@@ -418,31 +460,128 @@ select:focus {
     margin-top: 0;
 }
 
-/* PMI row */
-.pmi-row {
-    margin-top: 0.5rem;
+/* Scenario chips */
+.scenario-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    margin-bottom: 0.5rem;
 }
 
-.pmi-row .field {
-    max-width: 200px;
+.scenario-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.6rem;
+    border: 1.5px solid var(--border);
+    border-radius: 14px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.1s;
+    color: var(--text-2);
+    background: var(--surface);
 }
 
-.hint {
-    font-size: 0.6875rem;
+.scenario-chip.active {
+    color: var(--text);
+    border-width: 2px;
+}
+
+.scenario-chip.locked {
+    cursor: default;
+}
+
+.chip-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.chip-edit, .chip-delete {
+    background: none;
+    border: none;
     color: var(--text-3);
-    margin-top: 0.4rem;
-    line-height: 1.45;
+    cursor: pointer;
+    font-size: 0.75rem;
+    padding: 0 0.1rem;
+    line-height: 1;
 }
 
-.hint.warning {
-    color: #c0392b;
-    font-size: 0.8125rem;
-    font-weight: 600;
+.chip-edit:hover { color: var(--text); }
+.chip-delete:hover { color: #c0392b; }
+
+/* Scenario editor */
+.scenario-editor {
+    margin-top: 0.5rem;
+    padding: 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    display: none;
+}
+
+.scenario-editor.visible { display: block; }
+
+.scenario-editor .input-row {
+    margin-bottom: 0.5rem;
+}
+
+.scenario-editor .field {
+    min-width: 100px;
+}
+
+.color-swatches {
+    display: flex;
+    gap: 0.35rem;
+    margin-top: 0.25rem;
+}
+
+.color-swatch {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    border: 2px solid transparent;
+    cursor: pointer;
+    transition: border-color 0.1s;
+}
+
+.color-swatch.selected {
+    border-color: var(--text);
+}
+
+.scenario-editor-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+}
+
+.scenario-editor-actions .btn-link {
+    flex: none;
+    width: auto;
+    padding: 0.35rem 0.8rem;
+}
+
+.custom-rates-list {
     margin-top: 0.5rem;
 }
 
-:root[data-theme="dark"] .hint.warning {
-    color: #e85555;
+.custom-rate-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.35rem;
+}
+
+.custom-rate-row .term-label {
+    font-size: 0.75rem;
+    color: var(--text-3);
+    min-width: 50px;
+}
+
+.custom-rate-row .input-wrap {
+    max-width: 120px;
 }
 
 /* Term cards */
@@ -484,19 +623,15 @@ select:focus {
     transition: color 0.1s;
 }
 
-.remove-term:hover {
-    color: #c0392b;
-}
+.remove-term:hover { color: #c0392b; }
 
 .term-fields {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr;
     gap: 0.5rem;
 }
 
-.term-fields .field {
-    min-width: 0;
-}
+.term-fields .field { min-width: 0; }
 
 .btn-link {
     background: var(--surface);
@@ -523,9 +658,7 @@ select:focus {
     display: none;
 }
 
-.results-section.visible {
-    display: block;
-}
+.results-section.visible { display: block; }
 
 .result-summary {
     display: grid;
@@ -565,15 +698,20 @@ select:focus {
     color: #fff;
 }
 
-.summary-card.accent .label {
-    color: rgba(255,255,255,0.55);
+.summary-card.accent .label { color: rgba(255,255,255,0.55); }
+.summary-card.accent .value { color: #fff; }
+
+:root[data-theme="dark"] .summary-card.accent {
+    background: #e0e0e0;
+    border-color: #e0e0e0;
+    color: #1a1a1a;
 }
 
-.summary-card.accent .value {
-    color: #fff;
-}
+:root[data-theme="dark"] .summary-card.accent .label { color: rgba(26,26,26,0.55); }
+:root[data-theme="dark"] .summary-card.accent .value { color: #1a1a1a; }
 
-.biweekly-compare {
+/* Frequency comparison */
+.freq-compare {
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius);
@@ -584,11 +722,12 @@ select:focus {
     line-height: 1.5;
 }
 
-.biweekly-compare strong {
+.freq-compare strong {
     color: var(--text);
     font-weight: 600;
 }
 
+/* Term results */
 .term-result {
     border: 1px solid var(--border);
     border-radius: var(--radius);
@@ -629,6 +768,13 @@ select:focus {
     color: var(--text);
 }
 
+.term-remaining {
+    margin-top: 0.35rem;
+    font-size: 0.75rem;
+    color: var(--text-3);
+    font-style: italic;
+}
+
 /* Scenario comparison */
 .scenario-compare {
     margin-bottom: 1.25rem;
@@ -656,9 +802,7 @@ select:focus {
     white-space: nowrap;
 }
 
-.scenario-table th:first-child {
-    text-align: left;
-}
+.scenario-table th:first-child { text-align: left; }
 
 .scenario-table td {
     padding: 0.4rem 0.7rem;
@@ -676,63 +820,76 @@ select:focus {
     color: var(--text-2);
 }
 
-.scenario-table tr:last-child td {
-    border-bottom: none;
-}
+.scenario-table tr:last-child td { border-bottom: none; }
 
 .scenario-label {
     font-size: 0.625rem;
     font-weight: 600;
     letter-spacing: 0.05em;
     text-transform: uppercase;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
 }
 
-.scenario-label.opt { color: #2a7a4a; }
-.scenario-label.pess { color: #a83232; }
-
-:root[data-theme="dark"] .scenario-label.opt { color: #4eca7a; }
-:root[data-theme="dark"] .scenario-label.pess { color: #e85555; }
-
-/* Dark mode: accent card uses inverted scheme */
-:root[data-theme="dark"] .summary-card.accent {
-    background: #e0e0e0;
-    border-color: #e0e0e0;
-    color: #1a1a1a;
-}
-:root[data-theme="dark"] .summary-card.accent .label {
-    color: rgba(26,26,26,0.55);
-}
-:root[data-theme="dark"] .summary-card.accent .value {
-    color: #1a1a1a;
+.scenario-label .chip-dot {
+    width: 6px;
+    height: 6px;
 }
 
-/* Dark mode: active buttons */
-:root[data-theme="dark"] .country-btn.active,
-:root[data-theme="dark"] .toggle-btn.active {
-    background: var(--text);
-    color: var(--bg);
+/* Savings cards */
+.savings-section {
+    display: none;
 }
 
-/* Dark mode: inputs */
-:root[data-theme="dark"] .input-wrap input {
-    background: transparent;
-    color: var(--text);
-    caret-color: var(--text);
+.savings-section.visible { display: block; }
+
+.savings-cards-row {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
 }
 
-:root[data-theme="dark"] .input-wrap input[readonly] {
-    color: var(--text-3);
-}
-
-:root[data-theme="dark"] select {
+.savings-card {
+    flex: 1;
+    min-width: 200px;
     background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.75rem 0.9rem;
+}
+
+.savings-card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-bottom: 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: var(--text-2);
+}
+
+.savings-card-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.8125rem;
+    margin-bottom: 0.2rem;
+    color: var(--text-2);
+}
+
+.savings-card-row .delta {
+    font-family: var(--mono);
+    font-weight: 500;
     color: var(--text);
 }
 
-:root[data-theme="dark"] .input-wrap input:-webkit-autofill {
-    -webkit-box-shadow: 0 0 0 30px #242424 inset;
-    -webkit-text-fill-color: var(--text);
-}
+.savings-card-row .delta.negative { color: #2a7a4a; }
+.savings-card-row .delta.positive { color: #c0392b; }
+
+:root[data-theme="dark"] .savings-card-row .delta.negative { color: #4eca7a; }
+:root[data-theme="dark"] .savings-card-row .delta.positive { color: #e85555; }
 
 /* Missing years */
 .missing-years {
@@ -752,18 +909,79 @@ select:focus {
     font-family: var(--mono);
 }
 
+.hint {
+    font-size: 0.6875rem;
+    color: var(--text-3);
+    margin-top: 0.4rem;
+    line-height: 1.45;
+}
+
+.hint.warning {
+    color: #c0392b;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    margin-top: 0.5rem;
+}
+
+:root[data-theme="dark"] .hint.warning { color: #e85555; }
+
 /* Charts */
-.chart-section {
+.charts-container {
     display: none;
 }
 
-.chart-section.visible {
-    display: block;
+.charts-container.visible { display: block; }
+
+.chart-tabs {
+    display: flex;
+    gap: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    margin-bottom: 0.75rem;
+    flex-wrap: wrap;
 }
 
-canvas {
+.chart-tab {
+    border: none;
+    background: var(--surface);
+    padding: 0.35rem 0.7rem;
+    font-size: 0.625rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    cursor: pointer;
+    color: var(--text-2);
+    transition: all 0.1s;
+    border-right: 1px solid var(--border);
+}
+
+.chart-tab:last-child { border-right: none; }
+
+.chart-tab.active {
+    background: var(--accent);
+    color: #fff;
+}
+
+.chart-panel {
+    display: none;
+    position: relative;
+}
+
+.chart-panel.visible { display: block; }
+
+.chart-panel canvas {
     width: 100%;
-    height: 280px;
+    max-height: 300px;
+}
+
+.ip-header {
+    margin-bottom: 0.5rem;
+}
+
+.ip-header select {
+    max-width: 180px;
+    font-size: 0.75rem;
 }
 
 /* Schedule toggle */
@@ -823,9 +1041,7 @@ canvas {
     top: 0;
 }
 
-#schedule-table th:first-child {
-    text-align: left;
-}
+#schedule-table th:first-child { text-align: left; }
 
 #schedule-table td {
     text-align: right;
@@ -844,6 +1060,62 @@ canvas {
     border-top: 2px solid var(--text-3);
 }
 
+/* Export */
+.export-section {
+    display: none;
+}
+
+.export-section.visible {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.export-btn {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.4rem 0.8rem;
+    color: var(--text-2);
+    cursor: pointer;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    transition: all 0.1s;
+}
+
+.export-btn:hover {
+    border-color: var(--text);
+    color: var(--text);
+}
+
+/* Dark mode overrides */
+:root[data-theme="dark"] .country-btn.active,
+:root[data-theme="dark"] .toggle-btn.active,
+:root[data-theme="dark"] .chart-tab.active {
+    background: var(--text);
+    color: var(--bg);
+}
+
+:root[data-theme="dark"] .input-wrap input {
+    background: transparent;
+    color: var(--text);
+    caret-color: var(--text);
+}
+
+:root[data-theme="dark"] .input-wrap input[readonly] { color: var(--text-3); }
+
+:root[data-theme="dark"] select {
+    background: var(--surface);
+    color: var(--text);
+}
+
+:root[data-theme="dark"] .input-wrap input:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 30px #242424 inset;
+    -webkit-text-fill-color: var(--text);
+}
+
 /* Footer */
 .tool-footer {
     margin-top: 3rem;
@@ -860,17 +1132,11 @@ canvas {
         padding: 1.25rem 0.75rem 3rem;
     }
 
-    .hook-line {
-        font-size: 1.2rem;
-    }
+    .hook-line { font-size: 1.2rem; }
 
-    .term-fields {
-        grid-template-columns: 1fr 1fr;
-    }
-    .result-summary {
-        grid-template-columns: 1fr 1fr;
-    }
-    .term-result-grid {
-        grid-template-columns: 1fr 1fr;
-    }
+    .term-fields { grid-template-columns: 1fr 1fr; }
+    .result-summary { grid-template-columns: 1fr 1fr; }
+    .term-result-grid { grid-template-columns: 1fr 1fr; }
+    .savings-cards-row { flex-direction: column; }
+    .chart-tab { font-size: 0.5625rem; padding: 0.3rem 0.45rem; }
 }


### PR DESCRIPTION
## Why

The multi-term mortgage calculator had incorrect formulas for Canadian mortgages, missing CMHC insurance handling, no payment frequency options, and no way to compare scenarios visually. This implements all 11 items from a detailed audit.

## What

**Bugs fixed:**
- Canadian semi-annual compounding formula: `(1 + rate/2)^(2/ppy) - 1` instead of `rate/12`. Verified against Canada.ca unit test values ($300k, 25yr at 2.5%/4%/5%/5.2%)
- CMHC premium: replaced ongoing `%/yr` field with one-time premium (4%/3.1%/2.8%) added to principal
- Year boundary in amortization: off-by-one for bi-weekly/weekly frequencies (used `p % ppy` instead of counter)
- Remaining months always showed 0; now computed from elapsed term years

**Removed (out of scope):**
- Property Tax, Home Insurance, HOA, Mortgage Insurance %/yr fields and all references in calculations, charts, and tables
- "Recurring Costs" section and pie chart that included those costs

**Added:**
- CMHC eligibility validation: $1.5M cap, 25/30yr amortization rules, first-time buyer and new build checkboxes
- 6 payment frequencies (monthly, semi-monthly, bi-weekly, accelerated bi-weekly, weekly, accelerated weekly)
- Per-term balance, cumulative interest, and "X yrs Y mos remaining" at each term boundary
- Named Scenario Manager (up to 5, offset or custom per-term rates, colour-coded chips as chart toggles)
- 4 multi-scenario Chart.js charts: balance over time, cumulative interest, payment step, I vs P stacked area
- Delta-vs-base tooltips on all line charts
- Savings-vs-Base cards per non-base scenario
- Export: shareable link (base64 URL), CSV, PNG chart export
- Source citations and intent comments on compounding formula, CMHC rules, payment frequencies, simulation engine
- localStorage v1 to v2 migration (Optimistic/Pessimistic → named scenarios)