### PR TITLE
Fix card overflow and add cumulative total paid chart

### DIFF
--- a/static/tools/multi-term-mortgage-calculator/index.html
+++ b/static/tools/multi-term-mortgage-calculator/index.html
@@ -185,6 +185,7 @@
         <div class="chart-tabs">
             <button class="chart-tab active" data-chart="balance">Balance Over Time</button>
             <button class="chart-tab" data-chart="cumulative">Cumulative Interest</button>
+            <button class="chart-tab" data-chart="total-paid">Cumulative Total Paid</button>
             <button class="chart-tab" data-chart="payment">Payment Over Time</button>
             <button class="chart-tab" data-chart="ip">Interest vs Principal</button>
             <button class="chart-tab" data-chart="interest-bar">Interest Per Term</button>
@@ -194,6 +195,9 @@
         </div>
         <div class="chart-panel" id="panel-cumulative">
             <canvas id="cumulativeInterestChart"></canvas>
+        </div>
+        <div class="chart-panel" id="panel-total-paid">
+            <canvas id="totalPaidChart"></canvas>
         </div>
         <div class="chart-panel" id="panel-payment">
             <canvas id="paymentChart"></canvas>

--- a/static/tools/multi-term-mortgage-calculator/script.js
+++ b/static/tools/multi-term-mortgage-calculator/script.js
@@ -717,7 +717,7 @@
         var compounding = countryConfig[country].compounding;
         var ppy = frequencyConfig[freq].ppy;
         var cumulativeInterest = 0;
-        var annualSnapshots = [{ year: 0, balance: principal, cumulativeInterest: 0, annualPrincipal: 0, annualInterest: 0, termIndex: 0, payment: 0 }];
+        var annualSnapshots = [{ year: 0, balance: principal, cumulativeInterest: 0, cumulativePaid: 0, annualPrincipal: 0, annualInterest: 0, termIndex: 0, payment: 0 }];
         var yearPrincipal = 0;
         var yearInterest = 0;
         var currentPaymentYear = 0;
@@ -745,6 +745,7 @@
                         year: currentPaymentYear,
                         balance: Math.max(0, balance),
                         cumulativeInterest: cumulativeInterest,
+                        cumulativePaid: cumulativeInterest + (principal - Math.max(0, balance)),
                         annualPrincipal: yearPrincipal,
                         annualInterest: yearInterest,
                         termIndex: ti,
@@ -925,9 +926,8 @@
             '<div class="summary-card"><div class="label">Total Paid</div><div class="value">' + fmt(sim.totalPaid) + '</div></div>' +
             '<div class="summary-card"><div class="label">Total Principal</div><div class="value">' + fmt(sim.totalPrincipalPaid) + '</div></div>' +
             '<div class="summary-card"><div class="label">Total Interest</div><div class="value">' + fmt(sim.totalInterest) + '</div></div>' +
-            '</div>' +
-            '<div class="result-summary" style="margin-bottom:1.25rem">' +
-            '<div class="summary-card accent"><div class="label">Interest / Payments</div><div class="value">' + fmtPct(sim.totalPaid > 0 ? sim.totalInterest / sim.totalPaid * 100 : 0) + '</div></div>';
+            '<div class="summary-card accent"><div class="label">Interest / Payments</div><div class="value">' + fmtPct(sim.totalPaid > 0 ? sim.totalInterest / sim.totalPaid * 100 : 0) + '</div></div>' +
+            '</div>';
 
         // CMHC premium card
         var hv = parseFloat($("home-value").value) || 0;
@@ -1099,9 +1099,10 @@
 
     // ===== CHARTS =====
     //
-    // Four multi-scenario charts driven by the amortization data:
+    // Five charts driven by the amortization data:
     //   A — Outstanding Balance Over Time (area chart, one line per scenario)
     //   B — Cumulative Interest Paid Over Time (line chart)
+    //   B2 — Cumulative Total Paid Over Time (line chart, interest + principal)
     //   C — Monthly Payment Over Time (step chart, steps at term renewals)
     //   D — Annual Interest vs Principal Split (stacked area, per-scenario selector)
     //
@@ -1141,6 +1142,9 @@
 
         // Chart B: Cumulative Interest
         drawLineChart("cumulativeInterestChart", results, visibleScenarios, "cumulativeInterest", "Cumulative Interest", "Interest ($)", gridColor, textColor, termBoundaries);
+
+        // Chart B2: Cumulative Total Paid (interest + principal)
+        drawLineChart("totalPaidChart", results, visibleScenarios, "cumulativePaid", "Cumulative Total Paid", "Total Paid ($)", gridColor, textColor, termBoundaries);
 
         // Chart C: Payment Over Time (step chart)
         drawPaymentChart(results, visibleScenarios, gridColor, textColor, termBoundaries);
@@ -1641,7 +1645,7 @@
 
     $("btn-png").addEventListener("click", function () {
         // Export the currently visible chart panel as PNG
-        var panels = ["balance", "cumulative", "payment", "ip"];
+        var panels = ["balance", "cumulative", "total-paid", "payment", "ip"];
         var visibleCanvas = null;
         for (var i = 0; i < panels.length; i++) {
             var panel = $("panel-" + panels[i]);

--- a/static/tools/multi-term-mortgage-calculator/style.css
+++ b/static/tools/multi-term-mortgage-calculator/style.css
@@ -662,7 +662,7 @@ select:focus {
 
 .result-summary {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
     gap: 0.375rem;
     margin-bottom: 1.25rem;
 }
@@ -673,6 +673,8 @@ select:focus {
     border-radius: var(--radius);
     padding: 0.75rem 0.9rem;
     text-align: left;
+    min-width: 0;
+    overflow: hidden;
 }
 
 .summary-card .label {
@@ -682,6 +684,9 @@ select:focus {
     text-transform: uppercase;
     color: var(--text-3);
     margin-bottom: 0.2rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .summary-card .value {
@@ -690,6 +695,8 @@ select:focus {
     font-family: var(--mono);
     letter-spacing: -0.02em;
     color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .summary-card.accent {
@@ -750,6 +757,7 @@ select:focus {
     grid-template-columns: 1fr 1fr 1fr;
     gap: 0.3rem 0.75rem;
     font-size: 0.8125rem;
+    min-width: 0;
 }
 
 .term-result-grid dt {
@@ -757,6 +765,9 @@ select:focus {
     font-size: 0.6875rem;
     font-weight: 500;
     letter-spacing: 0.02em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .term-result-grid dd {
@@ -766,6 +777,8 @@ select:focus {
     letter-spacing: -0.01em;
     margin-left: 0;
     color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .term-remaining {
@@ -852,7 +865,7 @@ select:focus {
 
 .savings-card {
     flex: 1;
-    min-width: 200px;
+    min-width: 0;
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius);
@@ -1137,6 +1150,8 @@ select:focus {
     .term-fields { grid-template-columns: 1fr 1fr; }
     .result-summary { grid-template-columns: 1fr 1fr; }
     .term-result-grid { grid-template-columns: 1fr 1fr; }
+    .term-result-grid dd { font-size: 0.75rem; }
+    .summary-card .value { font-size: 0.9375rem; }
     .savings-cards-row { flex-direction: column; }
     .chart-tab { font-size: 0.5625rem; padding: 0.3rem 0.45rem; }
 }


### PR DESCRIPTION
## Why

Summary cards and term result values get cut off on narrow screens when dollar amounts are long. The accent card sat alone in a 3-column grid row. No chart shows total cash outflow over time.

## What

- Add `min-width: 0`, `overflow: hidden`, `text-overflow: ellipsis` to summary card values and term result dd/dt elements
- Remove `min-width: 200px` from savings cards that forced horizontal overflow on mobile
- Consolidate 4 summary cards into one 4-column grid row (2x2 on mobile) instead of 3+1 in separate grids
- Add Cumulative Total Paid line chart showing interest + principal cash outflow over time
- Smaller font on summary values and term result values on mobile